### PR TITLE
Shorten the base name for deployed resources

### DIFF
--- a/Solutions/Marain.UserNotifications.Deployment/Marain-ArmDeploy.ps1
+++ b/Solutions/Marain.UserNotifications.Deployment/Marain-ArmDeploy.ps1
@@ -17,7 +17,7 @@ Function MarainDeployment([MarainServiceDeploymentContext] $ServiceDeploymentCon
     $ManagementAppId = $ServiceDeploymentContext.GetAppId("mng")
 
     $TemplateParameters = @{
-        appName="notifications"
+        appName="usrnoti"
         apiDeliveryChannelFunctionAuthAadClientId=$ApiDeliveryChannelAppId
         managementFunctionAuthAadClientId=$ManagementAppId
         operationsControlServiceBaseUrl=$OperationsService.BaseUrl


### PR DESCRIPTION
Due to the way in which we generate storage account names, and the limit of 24 characters that apply to them, we need to shorten the name we use when deploying user notifications resources. This PR requires a corresponding update to Marain.Instance once it has been merged and an updated release created.