### PR TITLE
Delivery channel creation and integration

### DIFF
--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -1,0 +1,81 @@
+# New delivery channel creation and integration
+
+## Status
+
+Proposed
+
+## Context
+
+Delivering notifications through different communication types (email, sms, web push notifications etc) is necessary in an extendable notifications service. Users should be able to choose which delivery channels (twilio, sendgrid, airship etc) they want to use for the associated communication type(s) as these said platforms could have different features or costs and if combined could provide less setup configuration/cost, which leaves the configuration totally up to the end user. 
+
+## Decision
+```
+                 +------------+
+                 |            |
+                 | Management |
+                 | API        |
+                 |            |
+                 |            |
+                 ++--+------+-+
+                  ^  ^      ^
+                  |  |      |
+         +--------+  |      +--------------+
+         |           |                     |
+         v           v                     v
++--------+-+      +--+-------+           +-+--------+
+|          |      |          |           |          |
+| Delivery |      | Delivery |           | Delivery |
+| Channel  |      | Channel  | +-+  +-+  | Channel  |
+| 1        |      | 2        |           | N        |
+|          |      |          |           |          |
+|          |      |          |           |          |
++----------+      +----------+           +----------+
+```
+
+The management api should have knowledge of what delivery channels are available and where certain notification types should be sent. As we send notifications through on a per user per tenant basis, user settings for which communication type(s) a user has allowed is read and a notification is sent to the available delivery channel(s). 
+
+### User notifications and user settings
+
+A user should be able to choose what kind of communication types they receive based on the notification type. There are two ways of approaching this, either:
+1. Send different types of notifications through all channels that are provided by the consumer of this service, and leave the communication type and user configuration for the consumer of the Marain.UserNotifications service. (ie, the consumer of the Marain.UserNotifications service should specify which channels they want to send notifications via an api call when a notification is created)
+2. Store user preferences somewhere that is accessible to the management api, then when a new type of notifications comes through, check what type of communications types  the user has agreed to use and then send a message through the delivery channel .
+
+The latter option was chosen as it provides a user the ability to choose what notifications they want out of the box, if the former is chosen, all users/businesses integrating with this service will then need to write their own notifications user management service.
+
+User settings for which notifications will go to what communication channels for each user will be stored inside a User Notifications Settings table which will be accessed by the Management Api. Configuration in this table will include the Notification Type and the appropriate communication types associated to that notification type. This table will have an associated crud api that will allow a user to view/change the stored settings.
+
+### Delivery Channels and Notification Types
+
+A delivery channel will need two types of setup, the first being the integration of the service with Marain and the second being configuration added in by a user to how this channel will be used in the current implementation (which notification types are permitted to which channels, templating, api keys etc).
+
+The management API will host configuration for what notification types can be sent through which delivery channels in the following format:
+
+```json
+[
+  {
+    "id": "",
+    "displayName": "",
+    "communicationTypes": [""],
+    "isConfigured": false
+  }
+]
+```
+where 'communicationTypes' specifies what communication types are supported in this Delivery Channel. This allows for consumers of Marain.UserNotifications to specify if they want to only use one kind communication type from a certain Delivery Channel that supports multiple types.
+
+A delivery channel will have a generic api that can be consumed by the Management Api and be able to transform data provided in the Notification into a format that is specific to that communication type (this will be discussed in a sequential adr). The result of this call will be a callback uri/null depending on how the delivery channel has been implemented.
+
+### Delivery Channel configuration 
+
+A delivery channel will also need the configuration of the underlying platform to be stored somewhere (api keys, secrets, etc). This will be stored in a generic manner so if a supported delivery channel needs to be used, an api key and slight modification of the settings in the management api will only be required. 
+
+Keys for the different platforms in the delivery channels will be stored in a format as follows:
+- `Marain:DeliveryChannel:<Platform_name>:<key_name>`
+- `Marain:DeliveryChannel:Airship:ApiMasterSecret`
+
+The Delivery Channel will also have to have it's own kind of configuration specifying the supported Communication Types. These will be hardcoded values and created when the coding of the new delivery channel is done. 
+
+### Delivery Channel usage
+
+The delivery channel will need to transform an object into the equivalent api model  used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodys, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (for twilio this will be a number, for web push this could be a mixture of business id and email, etc). 
+
+A solution to this would be to create a generic communication type object (smsobject, emailobject, webpushobject) that is provided by the management api to the delivery channel, and then the delivery channel can map a generic communication type object into the required api model. This might prove to be simpler when integrating new delivery channels in the future as most of the information will already be there.

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -1,5 +1,13 @@
 # New delivery channel creation and integration
 
+## Table of definitions
+
+| Word     | Definition                                                                                                                            |
+|----------|---------------------------------------------------------------------------------------------------------------------------------------|
+| Consumer | A service that uses the Marain.UserNotifications service                                                                              |
+| User     | The individual who is using an application that consumes the Marain.UserNotifications service                                         |
+| Service  | A software functionality or a set of software functionalities with a purpose that different clients can reuse for different purposes. |
+
 ## Status
 
 Proposed

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -55,29 +55,6 @@ The latter option was chosen as it provides a user the ability to choose what no
 
 Settings for which communication channel a user can receive a notification through will be stored inside a User Notifications Settings table which will be accessed by the Management Api. Configuration in this table will include the Notification Type and the appropriate communication types associated to that notification type. This table will have an associated crud api that will allow a consumer of `Marain.UserNotifications` to view/change the stored settings.
 
-### Management Api and usable Delivery Channels
-
-The management API will host configuration per tenant for what communication types can be sent through which delivery channels in the following format:
-
-```json
-[
-  {
-    "id": "dc1",
-    "displayName": "Airship",
-    "communicationTypes": ["email", "sms", "web-push"]
-  },
-  {
-    "id": "dc2",
-    "displayName": "Twilio",
-    "communicationTypes": ["sms"]
-  }
-]
-```
-
-where 'communicationTypes' specifies what communication types are supported in this Delivery Channel. This allows for consumers of Marain.UserNotifications to specify if they want to only use one kind communication type from a certain Delivery Channel that supports multiple communication types, eg: an organisation using `Marain.UserNotifications` can specify that they want to use sms's from twilio and only communication types from that delivery channel.
-
-A delivery channel will have a generic api that can be consumed by the Management Api and be able to transform data provided in the Notification into a format that is specific to that communication type (this will be discussed in a sequential adr). The result of this call will be a callback uri/null depending on how the delivery channel has been implemented.
-
 ### Delivery Channel configuration
 
 A delivery channel will need some configuration of the underlying platform (Airship, Twilio etc) to be stored somewhere for a certain tenant. This configuration will be used for api keys, secrets, certificates etc as well as storing which delivery channels the current tenant will use for specific communication types. 
@@ -115,6 +92,28 @@ There also needs to be an association between the used conmunication channels an
 }
 ```
 This configuration will be stored on a per tenant basis.
+
+### Management Api and usable Delivery Channels
+
+The management API will host configuration per tenant for what communication types can be sent through which delivery channels in the following format:
+
+```json
+[
+  {
+    "id": "dc1",
+    "displayName": "Airship",
+    "communicationTypes": ["email", "sms", "web-push"]
+  },
+  {
+    "id": "dc2",
+    "displayName": "Twilio",
+    "communicationTypes": ["sms"]
+  }
+]
+```
+where 'communicationTypes' specifies what communication types are supported in this Delivery Channel. This allows for consumers of Marain.UserNotifications to specify if they want to only use one kind communication type from a certain Delivery Channel that supports multiple communication types, eg: an organisation using `Marain.UserNotifications` can specify that they want to use sms's from twilio and only communication types from that delivery channel.
+
+A delivery channel will have a generic api that can be consumed by the Management Api and be able to transform data provided in the Notification into a format that is specific to that communication type (this will be discussed in a sequential adr). The result of this call will be a callback uri/null depending on how the delivery channel has been implemented.
 
 ### Delivery Channel usage
 

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -2,10 +2,10 @@
 
 ## Table of definitions
 
-| Word     | Definition                                                                                                                            |
-|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| Consumer | A service that uses the Marain.UserNotifications service                                                                              |
-| User     | The individual who is using an application that consumes the Marain.UserNotifications service                                         |
+| Word     | Definition                                                                                    |
+| -------- | --------------------------------------------------------------------------------------------- |
+| Consumer | A service that uses the Marain.UserNotifications service                                      |
+| User     | The individual who is using an application that consumes the Marain.UserNotifications service |
 
 ## Status
 
@@ -16,6 +16,7 @@ Proposed
 Delivering notifications through different communication types (email, sms, web push notifications etc) is necessary in an extendable notifications service. Organizations should be able to choose which delivery channels (twilio, sendgrid, airship etc) they want to use for the associated communication type(s) as these said platforms could have different features or costs. Sometimes using different communication types through multiple delivery channels could save costs rather than having multiple communication types through a single delivery channel.
 
 ## Decision
+
 ```
                  +------------+
                  |            |
@@ -39,19 +40,18 @@ Delivering notifications through different communication types (email, sms, web 
 +----------+      +----------+           +----------+
 ```
 
-The management api should have knowledge of what delivery channels are available and where certain notification types should be sent. 
+The management api should have knowledge of what delivery channels are available and where certain notification types should be sent.
 
 When a new notification for a user is sent to the management api, the management api will read the user preference for the said notification type and see which communication types the user has 'subscribed' to. Following this, the notification delivered through the appropriate delivery channel.
 
 ### User notifications and user settings
 
 A user should be able to choose what kind of communication types they receive based on the notification type. There are two ways of approaching this, either:
+
 1. Send different types of notifications through all channels that are provided by the consumer of this service, and leave the communication type and user configuration for the consumer of the Marain.UserNotifications service. (ie, the consumer of the Marain.UserNotifications service should specify which delivery channels they want to send notifications via an api call when a notification is created)
-2. Store user preferences somewhere that is accessible to the management api, then when a new notification with a certain notification type comes through, check what type of communication types  the user has 'subscribed' to and then send a message through the delivery channel.
+2. Store user preferences somewhere that is accessible to the management api, then when a new notification with a certain notification type comes through, check what type of communication types the user has 'subscribed' to and then send a message through the delivery channel.
 
 The latter option was chosen as it provides a user the ability to choose what notifications they want out of the box, if the former is chosen, all users/businesses integrating with this service will then need to write their own notifications user management service.
-
-
 
 Settings for which communication channel a user can receive a notification through will be stored inside a User Notifications Settings table which will be accessed by the Management Api. Configuration in this table will include the Notification Type and the appropriate communication types associated to that notification type. This table will have an associated crud api that will allow a consumer of `Marain.UserNotifications` to view/change the stored settings.
 
@@ -65,7 +65,7 @@ The management API will host configuration per tenant for what communication typ
     "id": "dc1",
     "displayName": "Airship",
     "communicationTypes": ["email", "sms", "web-push"]
-  }, 
+  },
   {
     "id": "dc2",
     "displayName": "Twilio",
@@ -73,30 +73,51 @@ The management API will host configuration per tenant for what communication typ
   }
 ]
 ```
+
 where 'communicationTypes' specifies what communication types are supported in this Delivery Channel. This allows for consumers of Marain.UserNotifications to specify if they want to only use one kind communication type from a certain Delivery Channel that supports multiple communication types, eg: an organisation using `Marain.UserNotifications` can specify that they want to use sms's from twilio and only communication types from that delivery channel.
 
 A delivery channel will have a generic api that can be consumed by the Management Api and be able to transform data provided in the Notification into a format that is specific to that communication type (this will be discussed in a sequential adr). The result of this call will be a callback uri/null depending on how the delivery channel has been implemented.
 
-### Delivery Channel configuration 
+### Delivery Channel configuration
 
-A delivery channel will also need the configuration of the underlying platform to be stored somewhere (api keys, secrets, etc). This will be stored in the `Marain.UserNotifications` keyvault. If a delivery channel needs to be used, there are two things that need to be added/modified:
-1. Modify the `Marain.UserNotifications` key vault secrets setion with the correct key/value pair (this is described in more details below).
-2. Update the configuration for the delivery channel in the management api to specify which communication types will use the delivery channel. 
+A delivery channel will need some configuration of the underlying platform (Airship, Twilio etc) to be stored somewhere for a certain tenant. This configuration will be used for api keys, secrets, certificates etc as well as storing which delivery channels the current tenant will use for specific communication types. 
 
-Keys for the different platforms in the delivery channels will be stored in a format as follows:
-`<TenantId>-<key_name>`
- an example with this format would look like:
-`75b9261673c2714681f14c97bc0439fb00000000000000000000000000000000-ApiMasterSecret`
+Api Keys/secrets for a platform in a delivery channel will be stored as a JSON in an Azure Keyvault for a single tenant.
 
-A key vault will be associated to each channel in the `Marain.UserNotifications` These key vaults will be created with the following format:
-`deliverychannel-<ChannelName>`
-an example with this format would be:
-`deliverychannel-airship`
+Below is an example of the configuration keys for [Airship](https://docs.airship.com/reference/security/app-keys-secrets/) would be stored as a json in the keyvault.
+```json
+{
+  "ApplicationKey": "notSoRandomApplicationKey1",
+  "ApplicationSecret": "notSoRandomApplicationSecret",
+  "MasterSecret": "notSoRandomMasterSecret"
+}
+```
+This object will be stored in a keyvault that is owned by the consumer of Marain.UserNotiificiations.
 
-The Delivery Channel will also have to have it's own kind of configuration specifying the supported Communication Types. These will be hardcoded values and created when the coding of the new delivery channel is done. 
+There also needs to be an association between the used conmunication channels and the configured delivery channels. An example of an object that would do this is shown below. The information stored in the `DeliveryChannels` array will only provide a link to the azure keyvault where the secrets/keys for the delivery channel are stored (this is a link to where the above object is stored).
+```json
+{
+  "DeliveryChannels": [
+    {
+      "Airship": {
+        "keyvaultEndpoint": "https://anexample.vault.azure.net/secrets/XDeliveryChannelConfig"
+      },
+      "Twilio": {
+        "keyvaultEndpoint": "https://anexample.vault.azure.net/secrets/XDeliveryChannelConfig"
+      }
+    }
+  ],
+  "CommunicationChannel": {
+    "Email": { "DeliveryChannel": "Twilio" },
+    "Sms": { "DeliveryChannel": "Twilio" },
+    "WebPush": { "DeliveryChannel": "Airship" }
+  }
+}
+```
+This configuration will be stored on a per tenant basis.
 
 ### Delivery Channel usage
 
-The delivery channel will need to transform an object into the equivalent api model used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodys, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (eg. twilio this will be a number, for web push this could be a mixture of business id and email, etc). 
+The delivery channel will need to transform an object into the equivalent api model used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodys, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (eg. twilio this will be a number, for web push this could be a mixture of business id and email, etc).
 
 A solution to this would be to create a generic type object for each commucication type (eg. smsobject, emailobject, webpushobject) that is provided by the management api to the delivery channel, and then the delivery channel can map a generic communication type object into the required api model. This will prove to be simpler when integrating new delivery channels in the future as most of the information will already be there.

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -1,5 +1,12 @@
 # New delivery channel creation and integration
 
+## Definitions/Terms used in this document
+| Word/Phrase  | Meaning  |
+|---|---|
+| end user  | A client/user who is using a system that uses Marain.UserNotifications in the backeground to handle the delivery of notifications  |
+| application developer | A developer who integrates and/or mantains Marain.UserNotifications in their application () |
+| | |
+
 ## Status
 
 Proposed
@@ -38,13 +45,15 @@ When a new notification for a user is sent to the management api, the management
 
 ### User notifications and user settings
 
-A user should be able to choose what kind of communication types they receive based on the notification type and notification severity. There are two ways of approaching this, either:
+A user should be able to choose what kind of communication types they receive based on the notification type. There are two ways of approaching this, either:
 1. Send different types of notifications through all channels that are provided by the consumer of this service, and leave the communication type and user configuration for the consumer of the Marain.UserNotifications service. (ie, the consumer of the Marain.UserNotifications service should specify which delivery channels they want to send notifications via an api call when a notification is created)
-2. Store user preferences somewhere that is accessible to the management api, then when a new notification with a certain notification type and notification severity comes through, check what type of communication types  the user has 'subscribed' to and then send a message through the delivery channel.
+2. Store user preferences somewhere that is accessible to the management api, then when a new notification with a certain notification type comes through, check what type of communication types  the user has 'subscribed' to and then send a message through the delivery channel.
 
 The latter option was chosen as it provides a user the ability to choose what notifications they want out of the box, if the former is chosen, all users/businesses integrating with this service will then need to write their own notifications user management service.
 
-User settings for which notifications will go to what communication types for each user will be stored inside a User Notifications Settings table which will be accessed by the Management Api. Configuration in this table will include the Notification Type and the appropriate communication types associated to that notification type. This table will have an associated crud api that will allow a user to view/change the stored settings.
+
+
+Settings for which communication channel a user can receive a notification through will be stored inside a User Notifications Settings table which will be accessed by the Management Api. Configuration in this table will include the Notification Type and the appropriate communication types associated to that notification type. This table will have an associated crud api that will allow a consumer of `Marain.UserNotifications` to view/change the stored settings.
 
 ### Management Api and usable Delivery Channels
 
@@ -70,11 +79,19 @@ A delivery channel will have a generic api that can be consumed by the Managemen
 
 ### Delivery Channel configuration 
 
-A delivery channel will also need the configuration of the underlying platform to be stored somewhere (api keys, secrets, etc). This will be stored in a keyvault. If a delivery channel needs to be used, modifying the keyvault with the correct key and updating the configuration for the delivery channel in the management api to specify which communication types will be used. 
+A delivery channel will also need the configuration of the underlying platform to be stored somewhere (api keys, secrets, etc). This will be stored in the `Marain.UserNotifications` keyvault. If a delivery channel needs to be used, there are two things that need to be added/modified:
+1. Modify the `Marain.UserNotifications` key vault secrets setion with the correct key/value pair (this is described in more details below).
+2. Update the configuration for the delivery channel in the management api to specify which communication types will use the delivery channel. 
 
 Keys for the different platforms in the delivery channels will be stored in a format as follows:
-- `Marain:DeliveryChannel:<Platform_name>:<key_name>`
-- `Marain:DeliveryChannel:Airship:ApiMasterSecret`
+`<TenantId>-<key_name>`
+ an example with this format would look like:
+`75b9261673c2714681f14c97bc0439fb00000000000000000000000000000000-ApiMasterSecret`
+
+A key vault will be associated to each channel in the `Marain.UserNotifications` These key vaults will be created with the following format:
+`deliverychannel-<ChannelName>`
+an example with this format would be:
+`deliverychannel-airship`
 
 The Delivery Channel will also have to have it's own kind of configuration specifying the supported Communication Types. These will be hardcoded values and created when the coding of the new delivery channel is done. 
 

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -13,7 +13,7 @@ Proposed
 
 ## Context
 
-Delivering notifications through different communication types (email, sms, web push notifications etc) is necessary in an extendable notifications service. Organizations should be able to choose which delivery channels (twilio, sendgrid, airship etc) they want to use for the associated communication type(s) as these said platforms could have different features or costs. Sometimes using different communication types through multiple delivery channels could save costs rather than having multiple communication types through a single delivery channel.
+Delivering notifications through different communication types (email, sms, web push notifications etc) is necessary in an extendable notifications service. Organizations should be able to choose which delivery channels (twilio, sendgrid, airship etc) they want to use for the associated communication type(s) as these said platforms could have different features or costs. This allows a consumer of `Marain.UserNotificaitons` to optimise their costs by selecting a specific platform for a certain commuincation type.
 
 ## Decision
 
@@ -118,6 +118,6 @@ This configuration will be stored on a per tenant basis.
 
 ### Delivery Channel usage
 
-The delivery channel will need to transform an object into the equivalent api model used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodys, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (eg. twilio this will be a number, for web push this could be a mixture of business id and email, etc).
+The delivery channel will need to transform an object into the equivalent api model used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodies, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (eg. twilio this will be a number, for web push this could be a mixture of business id and email, etc).
 
 A solution to this would be to create a generic type object for each commucication type (eg. smsobject, emailobject, webpushobject) that is provided by the management api to the delivery channel, and then the delivery channel can map a generic communication type object into the required api model. This will prove to be simpler when integrating new delivery channels in the future as most of the information will already be there.

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -6,7 +6,7 @@ Proposed
 
 ## Context
 
-Delivering notifications through different communication types (email, sms, web push notifications etc) is necessary in an extendable notifications service. Users should be able to choose which delivery channels (twilio, sendgrid, airship etc) they want to use for the associated communication type(s) as these said platforms could have different features or costs and if combined could provide less setup configuration/cost, which leaves the configuration totally up to the end user. 
+Delivering notifications through different communication types (email, sms, web push notifications etc) is necessary in an extendable notifications service. Organizations should be able to choose which delivery channels (twilio, sendgrid, airship etc) they want to use for the associated communication type(s) as these said platforms could have different features or costs. Sometimes using different communication types through multiple delivery channels could save costs rather than having multiple communication types through a single delivery channel.
 
 ## Decision
 ```
@@ -32,41 +32,45 @@ Delivering notifications through different communication types (email, sms, web 
 +----------+      +----------+           +----------+
 ```
 
-The management api should have knowledge of what delivery channels are available and where certain notification types should be sent. As we send notifications through on a per user per tenant basis, user settings for which communication type(s) a user has allowed is read and a notification is sent to the available delivery channel(s). 
+The management api should have knowledge of what delivery channels are available and where certain notification types should be sent. 
+
+When a new notification for a user is sent to the management api, the management api will read the user preference for the said notification type and see which communication types the user has 'subscribed' to. Following this, the notification delivered through the appropriate delivery channel.
 
 ### User notifications and user settings
 
-A user should be able to choose what kind of communication types they receive based on the notification type. There are two ways of approaching this, either:
-1. Send different types of notifications through all channels that are provided by the consumer of this service, and leave the communication type and user configuration for the consumer of the Marain.UserNotifications service. (ie, the consumer of the Marain.UserNotifications service should specify which channels they want to send notifications via an api call when a notification is created)
-2. Store user preferences somewhere that is accessible to the management api, then when a new type of notifications comes through, check what type of communications types  the user has agreed to use and then send a message through the delivery channel .
+A user should be able to choose what kind of communication types they receive based on the notification type and notification severity. There are two ways of approaching this, either:
+1. Send different types of notifications through all channels that are provided by the consumer of this service, and leave the communication type and user configuration for the consumer of the Marain.UserNotifications service. (ie, the consumer of the Marain.UserNotifications service should specify which delivery channels they want to send notifications via an api call when a notification is created)
+2. Store user preferences somewhere that is accessible to the management api, then when a new notification with a certain notification type and notification severity comes through, check what type of communication types  the user has 'subscribed' to and then send a message through the delivery channel.
 
 The latter option was chosen as it provides a user the ability to choose what notifications they want out of the box, if the former is chosen, all users/businesses integrating with this service will then need to write their own notifications user management service.
 
-User settings for which notifications will go to what communication channels for each user will be stored inside a User Notifications Settings table which will be accessed by the Management Api. Configuration in this table will include the Notification Type and the appropriate communication types associated to that notification type. This table will have an associated crud api that will allow a user to view/change the stored settings.
+User settings for which notifications will go to what communication types for each user will be stored inside a User Notifications Settings table which will be accessed by the Management Api. Configuration in this table will include the Notification Type and the appropriate communication types associated to that notification type. This table will have an associated crud api that will allow a user to view/change the stored settings.
 
-### Delivery Channels and Notification Types
+### Management Api and usable Delivery Channels
 
-A delivery channel will need two types of setup, the first being the integration of the service with Marain and the second being configuration added in by a user to how this channel will be used in the current implementation (which notification types are permitted to which channels, templating, api keys etc).
-
-The management API will host configuration for what notification types can be sent through which delivery channels in the following format:
+The management API will host configuration per tenant for what communication types can be sent through which delivery channels in the following format:
 
 ```json
 [
   {
-    "id": "",
-    "displayName": "",
-    "communicationTypes": [""],
-    "isConfigured": false
+    "id": "dc1",
+    "displayName": "Airship",
+    "communicationTypes": ["email", "sms", "web-push"]
+  }, 
+  {
+    "id": "dc2",
+    "displayName": "Twilio",
+    "communicationTypes": ["sms"]
   }
 ]
 ```
-where 'communicationTypes' specifies what communication types are supported in this Delivery Channel. This allows for consumers of Marain.UserNotifications to specify if they want to only use one kind communication type from a certain Delivery Channel that supports multiple types.
+where 'communicationTypes' specifies what communication types are supported in this Delivery Channel. This allows for consumers of Marain.UserNotifications to specify if they want to only use one kind communication type from a certain Delivery Channel that supports multiple communication types, eg: an organisation using `Marain.UserNotifications` can specify that they want to use sms's from twilio and only communication types from that delivery channel.
 
 A delivery channel will have a generic api that can be consumed by the Management Api and be able to transform data provided in the Notification into a format that is specific to that communication type (this will be discussed in a sequential adr). The result of this call will be a callback uri/null depending on how the delivery channel has been implemented.
 
 ### Delivery Channel configuration 
 
-A delivery channel will also need the configuration of the underlying platform to be stored somewhere (api keys, secrets, etc). This will be stored in a generic manner so if a supported delivery channel needs to be used, an api key and slight modification of the settings in the management api will only be required. 
+A delivery channel will also need the configuration of the underlying platform to be stored somewhere (api keys, secrets, etc). This will be stored in a keyvault. If a delivery channel needs to be used, modifying the keyvault with the correct key and updating the configuration for the delivery channel in the management api to specify which communication types will be used. 
 
 Keys for the different platforms in the delivery channels will be stored in a format as follows:
 - `Marain:DeliveryChannel:<Platform_name>:<key_name>`
@@ -76,6 +80,6 @@ The Delivery Channel will also have to have it's own kind of configuration speci
 
 ### Delivery Channel usage
 
-The delivery channel will need to transform an object into the equivalent api model  used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodys, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (for twilio this will be a number, for web push this could be a mixture of business id and email, etc). 
+The delivery channel will need to transform an object into the equivalent api model used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodys, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (eg. twilio this will be a number, for web push this could be a mixture of business id and email, etc). 
 
-A solution to this would be to create a generic communication type object (smsobject, emailobject, webpushobject) that is provided by the management api to the delivery channel, and then the delivery channel can map a generic communication type object into the required api model. This might prove to be simpler when integrating new delivery channels in the future as most of the information will already be there.
+A solution to this would be to create a generic type object for each commucication type (eg. smsobject, emailobject, webpushobject) that is provided by the management api to the delivery channel, and then the delivery channel can map a generic communication type object into the required api model. This will prove to be simpler when integrating new delivery channels in the future as most of the information will already be there.

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -1,12 +1,5 @@
 # New delivery channel creation and integration
 
-## Definitions/Terms used in this document
-| Word/Phrase  | Meaning  |
-|---|---|
-| end user  | A client/user who is using a system that uses Marain.UserNotifications in the backeground to handle the delivery of notifications  |
-| application developer | A developer who integrates and/or mantains Marain.UserNotifications in their application () |
-| | |
-
 ## Status
 
 Proposed

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -93,28 +93,6 @@ There also needs to be an association between the used conmunication channels an
 ```
 This configuration will be stored on a per tenant basis.
 
-### Management Api and usable Delivery Channels
-
-The management API will host configuration per tenant for what communication types can be sent through which delivery channels in the following format:
-
-```json
-[
-  {
-    "id": "dc1",
-    "displayName": "Airship",
-    "communicationTypes": ["email", "sms", "web-push"]
-  },
-  {
-    "id": "dc2",
-    "displayName": "Twilio",
-    "communicationTypes": ["sms"]
-  }
-]
-```
-where 'communicationTypes' specifies what communication types are supported in this Delivery Channel. This allows for consumers of Marain.UserNotifications to specify if they want to only use one kind communication type from a certain Delivery Channel that supports multiple communication types, eg: an organisation using `Marain.UserNotifications` can specify that they want to use sms's from twilio and only communication types from that delivery channel.
-
-A delivery channel will have a generic api that can be consumed by the Management Api and be able to transform data provided in the Notification into a format that is specific to that communication type (this will be discussed in a sequential adr). The result of this call will be a callback uri/null depending on how the delivery channel has been implemented.
-
 ### Delivery Channel usage
 
 The delivery channel will need to transform an object into the equivalent api model used to send a message by the chosen platform (twilio, airship, send grid etc). Some notifications will have different headings, bodies, generic templates that will have to be transformed into a format that is suitable and also might have different ways of targetting certain users depending on how the users are registered with the platforms. (eg. twilio this will be a number, for web push this could be a mixture of business id and email, etc).

--- a/docs/adr/0002-delivery-channel-creation-and-integration.md
+++ b/docs/adr/0002-delivery-channel-creation-and-integration.md
@@ -6,7 +6,6 @@
 |----------|---------------------------------------------------------------------------------------------------------------------------------------|
 | Consumer | A service that uses the Marain.UserNotifications service                                                                              |
 | User     | The individual who is using an application that consumes the Marain.UserNotifications service                                         |
-| Service  | A software functionality or a set of software functionalities with a purpose that different clients can reuse for different purposes. |
 
 ## Status
 


### PR DESCRIPTION
Delivering notifications through different communication types (email, sms, web push notifications etc) is necessary in an extendable notifications service. Users should be able to choose which delivery channels (twilio, sendgrid, airship etc) they want to use for the associated communication type(s) as these said platforms could have different features or costs and if combined could provide less setup configuration/cost, which leaves the configuration totally up to the end user. 

This ADR covers the setup, configuration and basic usage of delivery channels in this project.