### PR TITLE
Remove unnecessary nullable fields in ICommunicationTemplate implementations

### DIFF
--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/EmailTemplate.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/EmailTemplate.cs
@@ -14,21 +14,40 @@ namespace Marain.NotificationTemplates.CommunicationTemplates
         /// </summary>
         public const string RegisteredContentType = "application/vnd.marain.usernotifications.notificationtemplate.emailtemplate.v1";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmailTemplate"/> class.
+        /// </summary>
+        /// <param name="notificationType">The <see cref="NotificationType"/>.</param>
+        /// <param name="subject">The <see cref="Subject"/>.</param>
+        /// <param name="body">The <see cref="Body"/>.</param>
+        /// <param name="eTag">The <see cref="ETag"/>.</param>
+        public EmailTemplate(
+            string notificationType,
+            string subject,
+            string body,
+            string? eTag = null)
+        {
+            this.NotificationType = notificationType;
+            this.Subject = subject;
+            this.Body = body;
+            this.ETag = eTag;
+        }
+
         /// <inheritdoc/>
-        public string? NotificationType { get; set; }
+        public string NotificationType { get; }
 
         /// <inheritdoc/>
         public string? ETag { get; set; }
 
         /// <summary>
-        /// Gets or sets the body of the email.
+        /// Gets the body of the email.
         /// </summary>
-        public string? Body { get; set; }
+        public string Body { get; }
 
         /// <summary>
-        /// Gets or sets the subject of the email.
+        /// Gets the subject of the email.
         /// </summary>
-        public string? Subject { get; set; }
+        public string Subject { get; }
 
         /// <summary>
         /// Gets the registered content type used when this object is serialized/deserialized.

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/ICommunicationTemplate.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/ICommunicationTemplate.cs
@@ -17,13 +17,13 @@ namespace Marain.NotificationTemplates.CommunicationTemplates
         string ContentType { get; }
 
         /// <summary>
-        /// Gets or sets the notification type of the communication template.
+        /// Gets the notification type of the communication template.
         /// </summary>
-        string? NotificationType { get; set; }
+        string NotificationType { get; }
 
         /// <summary>
-        /// Gets or Sets the notification's etag.
+        /// Gets the notification's etag.
         /// </summary>
-        public string? ETag { get; set; }
+        public string? ETag { get; }
     }
 }

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/SmsTemplate.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/SmsTemplate.cs
@@ -14,16 +14,32 @@ namespace Marain.NotificationTemplates.CommunicationTemplates
         /// </summary>
         public const string RegisteredContentType = "application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SmsTemplate"/> class.
+        /// </summary>
+        /// <param name="notificationType">The <see cref="NotificationType"/>.</param>
+        /// <param name="body">The <see cref="Body"/>.</param>
+        /// <param name="eTag">The <see cref="ETag"/>.</param>
+        public SmsTemplate(
+            string notificationType,
+            string body,
+            string? eTag = null)
+        {
+            this.NotificationType = notificationType;
+            this.Body = body;
+            this.ETag = eTag;
+        }
+
         /// <inheritdoc/>
-        public string? NotificationType { get; set; }
+        public string NotificationType { get; }
 
         /// <inheritdoc/>
         public string? ETag { get; set; }
 
         /// <summary>
-        /// Gets or sets the body of the Sms object.
+        /// Gets the body of the Sms object.
         /// </summary>
-        public string? Body { get; set; }
+        public string Body { get; }
 
         /// <summary>
         /// Gets the registered content type used when this object is serialized/deserialized.

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/WebPushTemplate.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/CommunicationTemplates/WebPushTemplate.cs
@@ -14,31 +14,56 @@ namespace Marain.NotificationTemplates.CommunicationTemplates
         /// </summary>
         public const string RegisteredContentType = "application/vnd.marain.usernotifications.notificationtemplate.webpushtemplate.v1";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebPushTemplate"/> class.
+        /// </summary>
+        /// <param name="notificationType">The <see cref="NotificationType"/>.</param>
+        /// <param name="title">The <see cref="Title"/>.</param>
+        /// <param name="body">The <see cref="Body"/>.</param>
+        /// <param name="image">The <see cref="Image"/>.</param>
+        /// <param name="actionUrl">The <see cref="ActionUrl"/>.</param>
+        /// <param name="eTag">The <see cref="ETag"/>.</param>
+        public WebPushTemplate(
+            string notificationType,
+            string title,
+            string body,
+            string? image,
+            string? actionUrl,
+            string? eTag = null)
+        {
+            this.NotificationType = notificationType;
+            this.Title = title;
+            this.Body = body;
+            this.Image = image;
+            this.ActionUrl = actionUrl;
+            this.ETag = eTag;
+        }
+
         /// <inheritdoc/>
-        public string? NotificationType { get; set; }
+        public string NotificationType { get; }
 
         /// <inheritdoc/>
         public string? ETag { get; set; }
 
         /// <summary>
-        /// Gets or sets the body of a WebPush notification.
+        /// Gets the body of a WebPush notification.
         /// </summary>
-        public string? Body { get; set; }
+        public string Body { get; }
 
         /// <summary>
-        /// Gets or sets the title of the WebPush notification.
+        /// Gets the title of the WebPush notification.
         /// </summary>
-        public string? Title { get; set; }
+        public string Title { get; }
 
         /// <summary>
-        /// Gets or sets the Base64 image of a WebPush notification.
+        /// Gets the Base64 image of a WebPush notification.
         /// </summary>
-        public string? Image { get; set; }
+        public string? Image { get; }
 
         /// <summary>
-        /// Gets or sets navigation url on click of the notification.
+        /// Gets navigation url on click of the notification.
         /// </summary>
-        public string? ActionUrl { get; set; }
+        public string? ActionUrl { get; }
 
         /// <summary>
         /// Gets the registered content type used when this object is serialized/deserialized.

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Composer/GenerateTemplateComposer.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Composer/GenerateTemplateComposer.cs
@@ -66,12 +66,10 @@ namespace Marain.UserNotifications.Management.Host.Composer
                                 break;
                             }
 
-                            emailTemplate = new EmailTemplate()
-                            {
-                                NotificationType = notificationType,
-                                Body = emailBody,
-                                Subject = emailSubject,
-                            };
+                            emailTemplate = new EmailTemplate(
+                                notificationType,
+                                emailSubject,
+                                emailBody);
                         }
                         catch (Exception)
                         {
@@ -92,7 +90,7 @@ namespace Marain.UserNotifications.Management.Host.Composer
                                 break;
                             }
 
-                            smsTemplate = new SmsTemplate() { NotificationType = notificationType, Body = smsBody };
+                            smsTemplate = new SmsTemplate(notificationType, smsBody);
                         }
                         catch (Exception)
                         {
@@ -122,14 +120,12 @@ namespace Marain.UserNotifications.Management.Host.Composer
                                 break;
                             }
 
-                            webPushTemplate = new WebPushTemplate()
-                            {
-                                NotificationType = notificationType,
-                                Body = webPushBody,
-                                Title = webPushTitle,
-                                Image = webPushImage,
-                                ActionUrl = actionUrl,
-                            };
+                            webPushTemplate = new WebPushTemplate(
+                                notificationType,
+                                webPushTitle,
+                                webPushBody,
+                                webPushImage,
+                                actionUrl);
                         }
                         catch (Exception)
                         {

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GetTemplateService.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GetTemplateService.cs
@@ -82,7 +82,7 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
 
                     if (emailTemplateWrapper.Item1 is null)
                     {
-                        throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType.ToString()} was not found.");
+                        throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType} was not found.");
                     }
 
                     // Add etag to the EmailTemplate
@@ -95,7 +95,7 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
                     (SmsTemplate, string?) smsTemplateWrapper = await store.GetAsync<SmsTemplate>(notificationType, communicationType).ConfigureAwait(false);
                     if (smsTemplateWrapper.Item1 is null)
                     {
-                        throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType.ToString()} was not found.");
+                        throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType} was not found.");
                     }
 
                     // Add etag to the SmsTemplate
@@ -108,7 +108,7 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
                     (WebPushTemplate, string?) webpushWrapper = await store.GetAsync<WebPushTemplate>(notificationType, communicationType).ConfigureAwait(false);
                     if (webpushWrapper.Item1 is null)
                     {
-                        throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType.ToString()} was not found.");
+                        throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType} was not found.");
                     }
 
                     // Add etag to the WebPushTemplate
@@ -120,7 +120,7 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
 
             if (response is null)
             {
-                throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType.ToString()} was not found.");
+                throw new OpenApiNotFoundException($"The notification template for notificationType {notificationType} and communicationType {communicationType} was not found.");
             }
 
             OpenApiResult okResult = this.OkResult(response, "application/json");

--- a/Solutions/Marain.UserNotifications.Specs/Steps/DataSetupSteps.cs
+++ b/Solutions/Marain.UserNotifications.Specs/Steps/DataSetupSteps.cs
@@ -54,36 +54,30 @@ namespace Marain.UserNotifications.Specs.Steps
 
         public static WebPushTemplate BuildWebPushNotificationTemplateFrom(TableRow tableRow, string? eTag = null)
         {
-            return new WebPushTemplate()
-            {
-                Body = tableRow["body"],
-                Title = tableRow["title"],
-                Image = tableRow["image"],
-                NotificationType = tableRow["notificationType"],
-                ActionUrl = tableRow["actionUrl"],
-                ETag = eTag,
-            };
+            return new WebPushTemplate(
+                tableRow["notificationType"],
+                tableRow["title"],
+                tableRow["body"],
+                tableRow["image"],
+                tableRow["actionUrl"],
+                eTag);
         }
 
         public static EmailTemplate BuildEmailNotificationTemplateFrom(TableRow tableRow, string? eTag = null)
         {
-            return new EmailTemplate()
-            {
-                Body = tableRow["body"],
-                Subject = tableRow["subject"],
-                NotificationType = tableRow["notificationType"],
-                ETag = eTag,
-            };
+            return new EmailTemplate(
+                tableRow["notificationType"],
+                tableRow["subject"],
+                tableRow["body"],
+                eTag);
         }
 
         public static SmsTemplate BuildSmsNotificationTemplateFrom(TableRow tableRow, string? eTag = null)
         {
-            return new SmsTemplate()
-            {
-                Body = tableRow["body"],
-                NotificationType = tableRow["notificationType"],
-                ETag = tableRow.ContainsKey("eTag") ? tableRow["eTag"] : eTag,
-            };
+            return new SmsTemplate(
+                tableRow["notificationType"],
+                tableRow["body"],
+                tableRow.ContainsKey("eTag") ? tableRow["eTag"] : eTag);
         }
 
         public static NotificationTemplate BuildNotificationTemplateFrom(TableRow tableRow, JsonSerializerSettings serializerSettings)


### PR DESCRIPTION
Resolves #123 

Due to the way etags are currently implemented and used, they remain nullable and read/write. This will be addressed as part of issue #122.