### PR TITLE
Bring gitversion.yml in line with current tags

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,5 +4,5 @@ branches:
     regex: ^master
     tag: preview
     increment: patch
-next-version: "0.1"
+next-version: "0.3"
 


### PR DESCRIPTION
The gitversion.yml is currently out of sync with the tags on the repo - the most recent release is `0.3.0`. This PR updates `gitversion.yml` to bring the two back in line.