### PR TITLE
Add the ETag to the client response on the GET endpoints

### DIFF
--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
@@ -6,6 +6,7 @@ namespace Marain.UserNotifications.Client.Management
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.IO;
     using System.Net.Http;
     using System.Text.Json;
@@ -121,9 +122,12 @@ namespace Marain.UserNotifications.Client.Management
 
             WebPushTemplateResource result = await JsonSerializer.DeserializeAsync<WebPushTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
+            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddEtagToImmutableDictionary(response);
+
             return new ApiResponse<WebPushTemplateResource>(
                response.StatusCode,
-               result);
+               result,
+               immutableHeaderDictionary);
         }
 
         /// <inheritdoc />
@@ -162,9 +166,12 @@ namespace Marain.UserNotifications.Client.Management
 
             EmailTemplateResource result = await JsonSerializer.DeserializeAsync<EmailTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
+            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddEtagToImmutableDictionary(response);
+
             return new ApiResponse<EmailTemplateResource>(
                response.StatusCode,
-               result);
+               result,
+               immutableHeaderDictionary);
         }
 
         /// <inheritdoc />
@@ -203,9 +210,12 @@ namespace Marain.UserNotifications.Client.Management
 
             SmsTemplateResource result = await JsonSerializer.DeserializeAsync<SmsTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
+            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddEtagToImmutableDictionary(response);
+
             return new ApiResponse<SmsTemplateResource>(
                response.StatusCode,
-               result);
+               result,
+               immutableHeaderDictionary);
         }
 
         /// <inheritdoc />
@@ -298,6 +308,17 @@ namespace Marain.UserNotifications.Client.Management
             }
 
             return null;
+        }
+
+        private ImmutableDictionary<string, string> AddEtagToImmutableDictionary(HttpResponseMessage response)
+        {
+            ImmutableDictionary<string, string>.Builder builder = ImmutableDictionary.CreateBuilder<string, string>();
+            if (!string.IsNullOrEmpty(response.Headers.ETag?.Tag))
+            {
+                builder.Add("If-None-Match", response.Headers.ETag.Tag);
+            }
+
+            return builder.ToImmutable();
         }
     }
 }

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
@@ -122,7 +122,7 @@ namespace Marain.UserNotifications.Client.Management
 
             WebPushTemplateResource result = await JsonSerializer.DeserializeAsync<WebPushTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
-            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddEtagToImmutableDictionary(response);
+            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddETagToImmutableDictionary(response);
 
             return new ApiResponse<WebPushTemplateResource>(
                response.StatusCode,
@@ -166,7 +166,7 @@ namespace Marain.UserNotifications.Client.Management
 
             EmailTemplateResource result = await JsonSerializer.DeserializeAsync<EmailTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
-            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddEtagToImmutableDictionary(response);
+            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddETagToImmutableDictionary(response);
 
             return new ApiResponse<EmailTemplateResource>(
                response.StatusCode,
@@ -210,7 +210,7 @@ namespace Marain.UserNotifications.Client.Management
 
             SmsTemplateResource result = await JsonSerializer.DeserializeAsync<SmsTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
-            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddEtagToImmutableDictionary(response);
+            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddETagToImmutableDictionary(response);
 
             return new ApiResponse<SmsTemplateResource>(
                response.StatusCode,
@@ -310,7 +310,7 @@ namespace Marain.UserNotifications.Client.Management
             return null;
         }
 
-        private ImmutableDictionary<string, string> AddEtagToImmutableDictionary(HttpResponseMessage response)
+        private ImmutableDictionary<string, string> AddETagToImmutableDictionary(HttpResponseMessage response)
         {
             ImmutableDictionary<string, string>.Builder builder = ImmutableDictionary.CreateBuilder<string, string>();
             if (!string.IsNullOrEmpty(response.Headers.ETag?.Tag))

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
@@ -122,12 +122,10 @@ namespace Marain.UserNotifications.Client.Management
 
             WebPushTemplateResource result = await JsonSerializer.DeserializeAsync<WebPushTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
-            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddETagToImmutableDictionary(response);
-
             return new ApiResponse<WebPushTemplateResource>(
                response.StatusCode,
                result,
-               immutableHeaderDictionary);
+               WrapETagInImmutableDictionary(response));
         }
 
         /// <inheritdoc />
@@ -166,12 +164,10 @@ namespace Marain.UserNotifications.Client.Management
 
             EmailTemplateResource result = await JsonSerializer.DeserializeAsync<EmailTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
-            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddETagToImmutableDictionary(response);
-
             return new ApiResponse<EmailTemplateResource>(
                response.StatusCode,
                result,
-               immutableHeaderDictionary);
+               WrapETagInImmutableDictionary(response));
         }
 
         /// <inheritdoc />
@@ -210,12 +206,10 @@ namespace Marain.UserNotifications.Client.Management
 
             SmsTemplateResource result = await JsonSerializer.DeserializeAsync<SmsTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
 
-            ImmutableDictionary<string, string> immutableHeaderDictionary = this.AddETagToImmutableDictionary(response);
-
             return new ApiResponse<SmsTemplateResource>(
                response.StatusCode,
                result,
-               immutableHeaderDictionary);
+               WrapETagInImmutableDictionary(response));
         }
 
         /// <inheritdoc />
@@ -282,6 +276,17 @@ namespace Marain.UserNotifications.Client.Management
                 result);
         }
 
+        private static ImmutableDictionary<string, string> WrapETagInImmutableDictionary(HttpResponseMessage response)
+        {
+            ImmutableDictionary<string, string>.Builder builder = ImmutableDictionary.CreateBuilder<string, string>();
+            if (!string.IsNullOrEmpty(response.Headers.ETag?.Tag))
+            {
+                builder.Add("ETag", response.Headers.ETag.Tag);
+            }
+
+            return builder.ToImmutable();
+        }
+
         private HttpRequestMessage AddETagToHeader(HttpRequestMessage httpRequestMessage, string eTag)
         {
             if (!string.IsNullOrWhiteSpace(eTag))
@@ -308,17 +313,6 @@ namespace Marain.UserNotifications.Client.Management
             }
 
             return null;
-        }
-
-        private ImmutableDictionary<string, string> AddETagToImmutableDictionary(HttpResponseMessage response)
-        {
-            ImmutableDictionary<string, string>.Builder builder = ImmutableDictionary.CreateBuilder<string, string>();
-            if (!string.IsNullOrEmpty(response.Headers.ETag?.Tag))
-            {
-                builder.Add("ETag", response.Headers.ETag.Tag);
-            }
-
-            return builder.ToImmutable();
         }
     }
 }

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
@@ -315,7 +315,7 @@ namespace Marain.UserNotifications.Client.Management
             ImmutableDictionary<string, string>.Builder builder = ImmutableDictionary.CreateBuilder<string, string>();
             if (!string.IsNullOrEmpty(response.Headers.ETag?.Tag))
             {
-                builder.Add("If-None-Match", response.Headers.ETag.Tag);
+                builder.Add("ETag", response.Headers.ETag.Tag);
             }
 
             return builder.ToImmutable();

--- a/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature
+++ b/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature
@@ -49,7 +49,7 @@ Scenario: Get a Web Push notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template4' and communication type 'WebPush'
 	Then the client response status code should be 'OK'
-	And the client response should contain a 'If-None-Match' header
+	And the client response should contain a 'ETag' header
 	And the web push template in the UserManagement API response should have a 'Body' with value 'body'
 	And the web push template in the UserManagement API response should have a 'Title' with value 'test'
 	And the web push template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.webpushtemplate.v1'
@@ -101,7 +101,7 @@ Scenario: Get an email notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template6' and communication type 'Email'
 	Then the client response status code should be 'OK'
-	And the client response should contain a 'If-None-Match' header
+	And the client response should contain a 'ETag' header
 	And the email template in the UserManagement API response should have a 'Body' with value 'body'
 	And the email template in the UserManagement API response should have a 'Subject' with value 'test'
 	And the email template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.emailtemplate.v1'
@@ -150,7 +150,7 @@ Scenario: Get an sms notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template8' and communication type 'Sms'
 	Then the client response status code should be 'OK'
-	And the client response should contain a 'If-None-Match' header
+	And the client response should contain a 'ETag' header
 	And the sms template in the UserManagement API response should have a 'Body' with value 'body'
 	And the sms template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1'
 	And the sms template in the UserManagement API response should have a 'NotificationType' with value 'marain.test.template8'

--- a/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature
+++ b/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature
@@ -49,7 +49,7 @@ Scenario: Get a Web Push notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template4' and communication type 'WebPush'
 	Then the client response status code should be 'OK'
-    And the client response should contain a 'If-None-Match' header
+	And the client response should contain a 'If-None-Match' header
 	And the web push template in the UserManagement API response should have a 'Body' with value 'body'
 	And the web push template in the UserManagement API response should have a 'Title' with value 'test'
 	And the web push template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.webpushtemplate.v1'
@@ -101,7 +101,7 @@ Scenario: Get an email notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template6' and communication type 'Email'
 	Then the client response status code should be 'OK'
-    And the client response should contain a 'If-None-Match' header
+	And the client response should contain a 'If-None-Match' header
 	And the email template in the UserManagement API response should have a 'Body' with value 'body'
 	And the email template in the UserManagement API response should have a 'Subject' with value 'test'
 	And the email template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.emailtemplate.v1'
@@ -110,6 +110,7 @@ Scenario: Get an email notification template
 Scenario: Get a Email notification template that doesn't exist
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.notcreatedtemplate' and communication type 'Email'
 	Then the UserNotificationsApiException status code should be 'NotFound'
+
 ########################################
 # Sms notification template tests	   #
 ########################################
@@ -149,7 +150,7 @@ Scenario: Get an sms notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template8' and communication type 'Sms'
 	Then the client response status code should be 'OK'
-    And the client response should contain a 'If-None-Match' header
+	And the client response should contain a 'If-None-Match' header
 	And the sms template in the UserManagement API response should have a 'Body' with value 'body'
 	And the sms template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1'
 	And the sms template in the UserManagement API response should have a 'NotificationType' with value 'marain.test.template8'

--- a/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature
+++ b/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature
@@ -49,12 +49,17 @@ Scenario: Get a Web Push notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template4' and communication type 'WebPush'
 	Then the client response status code should be 'OK'
+    And the client response should contain a 'If-None-Match' header
 	And the web push template in the UserManagement API response should have a 'Body' with value 'body'
 	And the web push template in the UserManagement API response should have a 'Title' with value 'test'
 	And the web push template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.webpushtemplate.v1'
 	And the web push template in the UserManagement API response should have a 'Image' with value 'Base+64xddfa'
 	And the web push template in the UserManagement API response should have a 'NotificationType' with value 'marain.test.template4'
 	And the web push template in the UserManagement API response should have a 'ActionUrl' with value 'https://www.google.co.uk/'
+
+Scenario: Get a Web Push notification template that doesn't exist
+	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.notcreatedtemplate' and communication type 'WebPush'
+	Then the UserNotificationsApiException status code should be 'NotFound'
 
 #####################################
 # Email notification template tests #
@@ -96,11 +101,15 @@ Scenario: Get an email notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template6' and communication type 'Email'
 	Then the client response status code should be 'OK'
+    And the client response should contain a 'If-None-Match' header
 	And the email template in the UserManagement API response should have a 'Body' with value 'body'
 	And the email template in the UserManagement API response should have a 'Subject' with value 'test'
 	And the email template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.emailtemplate.v1'
 	And the email template in the UserManagement API response should have a 'NotificationType' with value 'marain.test.template6'
 
+Scenario: Get a Email notification template that doesn't exist
+	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.notcreatedtemplate' and communication type 'Email'
+	Then the UserNotificationsApiException status code should be 'NotFound'
 ########################################
 # Sms notification template tests	   #
 ########################################
@@ -140,6 +149,7 @@ Scenario: Get an sms notification template
 		"""
 	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template8' and communication type 'Sms'
 	Then the client response status code should be 'OK'
+    And the client response should contain a 'If-None-Match' header
 	And the sms template in the UserManagement API response should have a 'Body' with value 'body'
 	And the sms template in the UserManagement API response should have a 'ContentType' with value 'application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1'
 	And the sms template in the UserManagement API response should have a 'NotificationType' with value 'marain.test.template8'
@@ -151,3 +161,7 @@ Scenario: Request sms notification template by self link
 	And I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.template9' and communication type 'Sms'
 	When I use the client to send a management API request to get a sms notification template using the link called 'self' from the previous API response
 	Then the client response status code should be 'OK'
+
+Scenario: Get a sms notification template that doesn't exist
+	When I use the client to send the notification template API a request to get a notification template with notification type 'marain.test.notcreatedtemplate' and communication type 'Sms'
+	Then the UserNotificationsApiException status code should be 'NotFound'

--- a/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature.cs
+++ b/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature.cs
@@ -231,27 +231,30 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 52
+    testRunner.And("the client response should contain a \'If-None-Match\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 53
  testRunner.And("the web push template in the UserManagement API response should have a \'Body\' wit" +
                         "h value \'body\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 53
+#line 54
  testRunner.And("the web push template in the UserManagement API response should have a \'Title\' wi" +
                         "th value \'test\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 54
+#line 55
  testRunner.And("the web push template in the UserManagement API response should have a \'ContentTy" +
                         "pe\' with value \'application/vnd.marain.usernotifications.notificationtemplate.we" +
                         "bpushtemplate.v1\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 55
+#line 56
  testRunner.And("the web push template in the UserManagement API response should have a \'Image\' wi" +
                         "th value \'Base+64xddfa\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 56
+#line 57
  testRunner.And("the web push template in the UserManagement API response should have a \'Notificat" +
                         "ionType\' with value \'marain.test.template4\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 57
+#line 58
  testRunner.And("the web push template in the UserManagement API response should have a \'ActionUrl" +
                         "\' with value \'https://www.google.co.uk/\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -260,13 +263,13 @@ this.ScenarioInitialize(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Create an email notification template")]
-        public virtual void CreateAnEmailNotificationTemplate()
+        [NUnit.Framework.DescriptionAttribute("Get a Web Push notification template that doesn\'t exist")]
+        public virtual void GetAWebPushNotificationTemplateThatDoesntExist()
         {
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Create an email notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 62
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get a Web Push notification template that doesn\'t exist", null, tagsOfScenario, argumentsOfScenario);
+#line 60
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -286,13 +289,52 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 63
+#line 61
+ testRunner.When("I use the client to send the notification template API a request to get a notific" +
+                        "ation template with notification type \'marain.test.notcreatedtemplate\' and commu" +
+                        "nication type \'WebPush\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 62
+ testRunner.Then("the UserNotificationsApiException status code should be \'NotFound\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Create an email notification template")]
+        public virtual void CreateAnEmailNotificationTemplate()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Create an email notification template", null, tagsOfScenario, argumentsOfScenario);
+#line 67
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 68
  testRunner.When("I use the client to send the notification template API a request to create a new " +
                         "email notification template", "{\r\n\t\"body\": \"this is a test template\",\r\n\t\"contentType\": \"application/vnd.marain.u" +
                         "sernotifications.notificationtemplate.emailtemplate.v1\",\r\n\t\"notificationType\": \"" +
                         "marain.test.template\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 71
+#line 76
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -306,7 +348,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Update an email notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 73
+#line 78
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -336,16 +378,16 @@ this.ScenarioInitialize(scenarioInfo);
                             "test",
                             "application/vnd.marain.usernotifications.notificationtemplate.emailtemplate.v1",
                             "marain.test.template5"});
-#line 74
+#line 79
  testRunner.Given("I have created and stored an email notification template", ((string)(null)), table16, "Given ");
 #line hidden
-#line 77
+#line 82
  testRunner.When("I use the client to send the notification template API a request to update an ema" +
                         "il notification template", "{\r\n\t\"body\": \"this is an updated test template2\",\r\n\t\"contentType\": \"application/vn" +
                         "d.marain.usernotifications.notificationtemplate.emailtemplate.v1\",\r\n\t\"notificati" +
                         "onType\": \"marain.test.template5\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 85
+#line 90
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -359,7 +401,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get an email notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 87
+#line 92
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -379,36 +421,78 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 88
+#line 93
  testRunner.Given("I use the client to send the notification template API a request to create a new " +
                         "email notification template", "{\r\n\t\"body\": \"body\",\r\n\t\"subject\": \"test\",\r\n\t\"contentType\": \"application/vnd.marain" +
                         ".usernotifications.notificationtemplate.emailtemplate.v1\",\r\n\t\"notificationType\":" +
                         " \"marain.test.template6\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 97
+#line 102
  testRunner.When("I use the client to send the notification template API a request to get a notific" +
                         "ation template with notification type \'marain.test.template6\' and communication " +
                         "type \'Email\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 98
+#line 103
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 99
+#line 104
+    testRunner.And("the client response should contain a \'If-None-Match\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 105
  testRunner.And("the email template in the UserManagement API response should have a \'Body\' with v" +
                         "alue \'body\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 100
+#line 106
  testRunner.And("the email template in the UserManagement API response should have a \'Subject\' wit" +
                         "h value \'test\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 101
+#line 107
  testRunner.And("the email template in the UserManagement API response should have a \'ContentType\'" +
                         " with value \'application/vnd.marain.usernotifications.notificationtemplate.email" +
                         "template.v1\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 102
+#line 108
  testRunner.And("the email template in the UserManagement API response should have a \'Notification" +
                         "Type\' with value \'marain.test.template6\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Get a Email notification template that doesn\'t exist")]
+        public virtual void GetAEmailNotificationTemplateThatDoesntExist()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get a Email notification template that doesn\'t exist", null, tagsOfScenario, argumentsOfScenario);
+#line 110
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 111
+ testRunner.When("I use the client to send the notification template API a request to get a notific" +
+                        "ation template with notification type \'marain.test.notcreatedtemplate\' and commu" +
+                        "nication type \'Email\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 112
+ testRunner.Then("the UserNotificationsApiException status code should be \'NotFound\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
             this.ScenarioCleanup();
@@ -421,7 +505,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Create an sms notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 107
+#line 116
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -441,13 +525,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 108
+#line 117
  testRunner.When("I use the client to send the notification template API a request to create a new " +
                         "sms notification template", "{\r\n\t\"body\": \"this is a test template\",\r\n\t\"contentType\": \"application/vnd.marain.u" +
                         "sernotifications.notificationtemplate.smstemplate.v1\",\r\n\t\"notificationType\": \"ma" +
                         "rain.test.template\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 116
+#line 125
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -461,7 +545,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Update an sms notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 118
+#line 127
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -489,16 +573,16 @@ this.ScenarioInitialize(scenarioInfo);
                             "body",
                             "application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1",
                             "marain.test.template7"});
-#line 119
+#line 128
  testRunner.Given("I have created and stored an sms notification template", ((string)(null)), table17, "Given ");
 #line hidden
-#line 122
+#line 131
  testRunner.When("I use the client to send the notification template API a request to update an sms" +
                         " notification template", "{\r\n\t\"body\": \"this is an updated test template2\",\r\n\t\"contentType\": \"application/vn" +
                         "d.marain.usernotifications.notificationtemplate.smstemplate.v1\",\r\n\t\"notification" +
                         "Type\": \"marain.test.template7\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 130
+#line 139
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -512,7 +596,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get an sms notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 132
+#line 141
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -532,30 +616,33 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 133
+#line 142
  testRunner.Given("I use the client to send the notification template API a request to create a new " +
                         "sms notification template", "{\r\n\t\"body\": \"body\",\r\n\t\"contentType\": \"application/vnd.marain.usernotifications.no" +
                         "tificationtemplate.smstemplate.v1\",\r\n\t\"notificationType\": \"marain.test.template8" +
                         "\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 141
+#line 150
  testRunner.When("I use the client to send the notification template API a request to get a notific" +
                         "ation template with notification type \'marain.test.template8\' and communication " +
                         "type \'Sms\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 142
+#line 151
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 143
+#line 152
+    testRunner.And("the client response should contain a \'If-None-Match\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 153
  testRunner.And("the sms template in the UserManagement API response should have a \'Body\' with val" +
                         "ue \'body\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 144
+#line 154
  testRunner.And("the sms template in the UserManagement API response should have a \'ContentType\' w" +
                         "ith value \'application/vnd.marain.usernotifications.notificationtemplate.smstemp" +
                         "late.v1\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 145
+#line 155
  testRunner.And("the sms template in the UserManagement API response should have a \'NotificationTy" +
                         "pe\' with value \'marain.test.template8\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -570,7 +657,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Request sms notification template by self link", null, tagsOfScenario, argumentsOfScenario);
-#line 147
+#line 157
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -598,20 +685,59 @@ this.ScenarioInitialize(scenarioInfo);
                             "body",
                             "application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1",
                             "marain.test.template9"});
-#line 148
+#line 158
  testRunner.Given("I have created and stored an sms notification template", ((string)(null)), table18, "Given ");
 #line hidden
-#line 151
+#line 161
  testRunner.And("I use the client to send the notification template API a request to get a notific" +
                         "ation template with notification type \'marain.test.template9\' and communication " +
                         "type \'Sms\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 152
+#line 162
  testRunner.When("I use the client to send a management API request to get a sms notification templ" +
                         "ate using the link called \'self\' from the previous API response", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 153
+#line 163
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Get a sms notification template that doesn\'t exist")]
+        public virtual void GetASmsNotificationTemplateThatDoesntExist()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get a sms notification template that doesn\'t exist", null, tagsOfScenario, argumentsOfScenario);
+#line 165
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 166
+ testRunner.When("I use the client to send the notification template API a request to get a notific" +
+                        "ation template with notification type \'marain.test.notcreatedtemplate\' and commu" +
+                        "nication type \'Sms\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 167
+ testRunner.Then("the UserNotificationsApiException status code should be \'NotFound\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
             this.ScenarioCleanup();

--- a/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature.cs
+++ b/Solutions/Marain.UserNotifications.Specs/Features/ManagementApiClient/NotificationTemplate.feature.cs
@@ -231,7 +231,7 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 52
-    testRunner.And("the client response should contain a \'If-None-Match\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the client response should contain a \'ETag\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 53
  testRunner.And("the web push template in the UserManagement API response should have a \'Body\' wit" +
@@ -436,7 +436,7 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 104
-    testRunner.And("the client response should contain a \'If-None-Match\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the client response should contain a \'ETag\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 105
  testRunner.And("the email template in the UserManagement API response should have a \'Body\' with v" +
@@ -505,7 +505,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Create an sms notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 116
+#line 117
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -525,13 +525,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 117
+#line 118
  testRunner.When("I use the client to send the notification template API a request to create a new " +
                         "sms notification template", "{\r\n\t\"body\": \"this is a test template\",\r\n\t\"contentType\": \"application/vnd.marain.u" +
                         "sernotifications.notificationtemplate.smstemplate.v1\",\r\n\t\"notificationType\": \"ma" +
                         "rain.test.template\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 125
+#line 126
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -545,7 +545,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Update an sms notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 127
+#line 128
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -573,16 +573,16 @@ this.ScenarioInitialize(scenarioInfo);
                             "body",
                             "application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1",
                             "marain.test.template7"});
-#line 128
+#line 129
  testRunner.Given("I have created and stored an sms notification template", ((string)(null)), table17, "Given ");
 #line hidden
-#line 131
+#line 132
  testRunner.When("I use the client to send the notification template API a request to update an sms" +
                         " notification template", "{\r\n\t\"body\": \"this is an updated test template2\",\r\n\t\"contentType\": \"application/vn" +
                         "d.marain.usernotifications.notificationtemplate.smstemplate.v1\",\r\n\t\"notification" +
                         "Type\": \"marain.test.template7\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 139
+#line 140
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -596,7 +596,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get an sms notification template", null, tagsOfScenario, argumentsOfScenario);
-#line 141
+#line 142
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -616,33 +616,33 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 142
+#line 143
  testRunner.Given("I use the client to send the notification template API a request to create a new " +
                         "sms notification template", "{\r\n\t\"body\": \"body\",\r\n\t\"contentType\": \"application/vnd.marain.usernotifications.no" +
                         "tificationtemplate.smstemplate.v1\",\r\n\t\"notificationType\": \"marain.test.template8" +
                         "\"\r\n}", ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 150
+#line 151
  testRunner.When("I use the client to send the notification template API a request to get a notific" +
                         "ation template with notification type \'marain.test.template8\' and communication " +
                         "type \'Sms\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 151
+#line 152
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 152
-    testRunner.And("the client response should contain a \'If-None-Match\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
 #line 153
+ testRunner.And("the client response should contain a \'ETag\' header", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 154
  testRunner.And("the sms template in the UserManagement API response should have a \'Body\' with val" +
                         "ue \'body\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 154
+#line 155
  testRunner.And("the sms template in the UserManagement API response should have a \'ContentType\' w" +
                         "ith value \'application/vnd.marain.usernotifications.notificationtemplate.smstemp" +
                         "late.v1\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 155
+#line 156
  testRunner.And("the sms template in the UserManagement API response should have a \'NotificationTy" +
                         "pe\' with value \'marain.test.template8\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -657,7 +657,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Request sms notification template by self link", null, tagsOfScenario, argumentsOfScenario);
-#line 157
+#line 158
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -685,19 +685,19 @@ this.ScenarioInitialize(scenarioInfo);
                             "body",
                             "application/vnd.marain.usernotifications.notificationtemplate.smstemplate.v1",
                             "marain.test.template9"});
-#line 158
+#line 159
  testRunner.Given("I have created and stored an sms notification template", ((string)(null)), table18, "Given ");
 #line hidden
-#line 161
+#line 162
  testRunner.And("I use the client to send the notification template API a request to get a notific" +
                         "ation template with notification type \'marain.test.template9\' and communication " +
                         "type \'Sms\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 162
+#line 163
  testRunner.When("I use the client to send a management API request to get a sms notification templ" +
                         "ate using the link called \'self\' from the previous API response", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 163
+#line 164
  testRunner.Then("the client response status code should be \'OK\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -711,7 +711,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get a sms notification template that doesn\'t exist", null, tagsOfScenario, argumentsOfScenario);
-#line 165
+#line 166
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -731,12 +731,12 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 166
+#line 167
  testRunner.When("I use the client to send the notification template API a request to get a notific" +
                         "ation template with notification type \'marain.test.notcreatedtemplate\' and commu" +
                         "nication type \'Sms\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 167
+#line 168
  testRunner.Then("the UserNotificationsApiException status code should be \'NotFound\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }


### PR DESCRIPTION
This PR will add the ETag in the headers for the GET endpoints of the template service i.e WebPush, Email and SMS.