### PR TITLE
Fix analyzer messages and warnings

### DIFF
--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/NotificationTemplate.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/NotificationTemplate.cs
@@ -4,7 +4,6 @@
 
 namespace Marain.NotificationTemplates
 {
-    using System;
     using Marain.NotificationTemplates.CommunicationTemplates;
 
     /// <summary>

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/NotificationTemplateNotFoundException.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/NotificationTemplateNotFoundException.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1194 // Roslynator's 'all the constructors' fixation
-
 namespace Marain.NotificationTemplates
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/NotificationTemplateStoreConcurrencyException.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/NotificationTemplates/NotificationTemplateStoreConcurrencyException.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1194 // Roslynator's 'all the constructors' fixation
-
 namespace Marain.NotificationTemplates
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotification.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotification.cs
@@ -8,11 +8,12 @@ namespace Marain.UserNotifications
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Diagnostics;
-    using System.Security.Cryptography;
-    using System.Text;
+
     using Corvus.Json;
+
     using Marain.Helpers;
     using Marain.Models;
+
     using Newtonsoft.Json;
 
     /// <summary>
@@ -39,15 +40,13 @@ namespace Marain.UserNotifications
             DateTimeOffset timestamp,
             IPropertyBag properties,
             UserNotificationMetadata metadata,
-#pragma warning disable SA1011 // Closing square brackets should be spaced correctly
             IEnumerable<UserNotificationStatus>? channelStatuses = null,
             Dictionary<CommunicationType, string>? deliveryChannelConfiguredPerCommunicationType = null)
-#pragma warning restore SA1011 // Closing square brackets should be spaced correctly
         {
             this.Id = id;
             this.NotificationType = notificationType ?? throw new ArgumentNullException(nameof(notificationType));
             this.UserId = userId ?? throw new ArgumentNullException(nameof(userId));
-            this.Timestamp = timestamp != default ? timestamp.ToUniversalTime() : throw new ArgumentException(nameof(timestamp));
+            this.Timestamp = timestamp != default ? timestamp.ToUniversalTime() : throw new ArgumentException("Timestamp must not be zero", nameof(timestamp));
             this.Properties = properties ?? throw new ArgumentNullException(nameof(properties));
             this.Metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
             this.ChannelStatuses = channelStatuses?.ToImmutableArray() ?? ImmutableArray<UserNotificationStatus>.Empty;

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotificationExtensions.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotificationExtensions.cs
@@ -126,7 +126,7 @@ namespace Marain.UserNotifications
 
             var builder = deliveryStatuses.ToBuilder();
 
-            if (!(existingStatusForChannel is null))
+            if (existingStatusForChannel is not null)
             {
                 builder.Remove(existingStatusForChannel);
                 builder.Add(existingStatusForChannel.WithDeliveryStatus(newDeliveryStatus, effectiveDateTime, failureReason));
@@ -182,7 +182,7 @@ namespace Marain.UserNotifications
 
             var builder = deliveryStatuses.ToBuilder();
 
-            if (!(existingStatusForChannel is null))
+            if (existingStatusForChannel is not null)
             {
                 builder.Remove(existingStatusForChannel);
                 builder.Add(existingStatusForChannel.WithReadStatus(newReadStatus, effectiveDateTime));

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotificationNotFoundException.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotificationNotFoundException.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1194 // Roslynator's 'all the constructors' fixation
-
 namespace Marain.UserNotifications
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotificationStoreConcurrencyException.cs
+++ b/Solutions/Marain.UserNotifications.Abstractions/Marain/UserNotifications/UserNotificationStoreConcurrencyException.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1194 // Roslynator's 'all the constructors' fixation
-
 namespace Marain.UserNotifications
 {
     using System;

--- a/Solutions/Marain.UserNotifications.ApiDeliveryChannel.Host/Marain.UserNotifications.ApiDeliveryChannel.Host.csproj
+++ b/Solutions/Marain.UserNotifications.ApiDeliveryChannel.Host/Marain.UserNotifications.ApiDeliveryChannel.Host.csproj
@@ -32,15 +32,8 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
     <None Update="local.settings.template.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.406" />
   </ItemGroup>
 </Project>

--- a/Solutions/Marain.UserNotifications.Benchmarks/Benchmarks/ApiDeliveryChannelBenchmarks.cs
+++ b/Solutions/Marain.UserNotifications.Benchmarks/Benchmarks/ApiDeliveryChannelBenchmarks.cs
@@ -5,10 +5,9 @@
 namespace Benchmarks
 {
     using System;
-    using System.Net.Http;
     using System.Threading.Tasks;
+
     using BenchmarkDotNet.Attributes;
-    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
     /// Benchmarks for the API delivery channel.

--- a/Solutions/Marain.UserNotifications.Benchmarks/Benchmarks/ManagementApiBenchmarks.cs
+++ b/Solutions/Marain.UserNotifications.Benchmarks/Benchmarks/ManagementApiBenchmarks.cs
@@ -6,10 +6,10 @@ namespace Benchmarks
 {
     using System;
     using System.Collections.Generic;
-    using System.Net.Http;
-    using System.Text;
     using System.Threading.Tasks;
+
     using BenchmarkDotNet.Attributes;
+
     using Marain.UserNotifications.Client.Management.Requests;
 
     /// <summary>

--- a/Solutions/Marain.UserNotifications.Benchmarks/Marain.UserNotifications.Benchmarks.csproj
+++ b/Solutions/Marain.UserNotifications.Benchmarks/Marain.UserNotifications.Benchmarks.csproj
@@ -13,10 +13,29 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <!--
+    The reference to Microsoft.CodeAnalysis.CSharp is to prevent warnings from appearing for this project
+    in Visual Studio 2022. With version 17.1.0, and with version 6.0.200 of the .NET SDK installed, Visual
+    Studio was producing CS8032 warnings with this message:
+    
+    An instance of analyzer Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.CSharpDiagnosticAnalyzerFieldsAnalyzer cannot be created from C:\Users\xyzzy\.nuget\packages\microsoft.codeanalysis.analyzers\2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll: Could not load type 'Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.DiagnosticAnalyzerFieldsAnalyzer`4' from assembly 'Microsoft.CodeAnalysis.Analyzers, Version=3.3.3.10305, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
+    
+    These only appear in Visual Studio's Error List window. They don't appear in the build output, either in build agents
+    or in VS. They seem to be errors categorized under "IntelliSense" which generally means they came from the dynamic,
+    continuous execution of analyzers against the current code (including any unsaved edits), and not from a real build.
+    This appears to be an upshot of BenchmarkDotNet v0.13.1 having a dependency on Microsoft.CodeAnalysis.CSharp. It specifies
+    a version >= 2.10.0, and in the absence of any other requests, 2.10.0 is what we get. But that's quite old, and appears
+    to cause a conflict when code analyzers run in VS, because they are built for newer versions.
+    It's not clear why Visual Studio wouldn't just load versions of these libraries consistent with the compiler being
+    used by the tool chain. It might be a bug - apparently this problem surfaces from time to time, and often goes away
+    again with subsequent releases of Visual Studio:
+    https://docs.microsoft.com/en-us/answers/questions/244179/microsoftcodeanalysis-problem.html
+    It's also possible that some future release of BenchmarkDotNet will make this problem go away.
+    So it might be that we will be able to remove this reference to Microsoft.CodeAnalysis.CSharp again at some point
+    in the future. We don't really want it in here - it's not like this project uses that library directly. It's just
+    necessary with the current versions of everything on 2nd March 2022 if we are to avoid spurious warnings in VS.
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[6.0.*,)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[6.0.*,)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[6.0.*,)" />

--- a/Solutions/Marain.UserNotifications.Benchmarks/packages.lock.json
+++ b/Solutions/Marain.UserNotifications.Benchmarks/packages.lock.json
@@ -25,14 +25,13 @@
           "System.ValueTuple": "4.5.0"
         }
       },
-      "Endjin.RecommendedPractices.GitHub": {
+      "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[2.1.0, )",
-        "resolved": "2.1.0",
-        "contentHash": "I5hRIYqow1UTBh+mlsaC23Pi1ISIbc04HUeDbdnmv4a3tCZyOEYOJF8Q/SVWbSEdh9chEPYSr6qfdltv/GrCPA==",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "sbu6kDGzo9bfQxuqWpeEE7I9P30bSuZEnpDz9/qz20OU6pm79Z63+/BsAzO2e/R/Q97kBrpj647wokZnEVr97w==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.1.0",
-          "Microsoft.SourceLink.GitHub": "1.1.1"
+          "Microsoft.CodeAnalysis.Common": "[4.1.0]"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -84,21 +83,6 @@
           "Microsoft.Extensions.Configuration.FileExtensions": "6.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "6.0.0",
           "System.Text.Json": "6.0.0"
-        }
-      },
-      "Roslynator.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.0.2, )",
-        "resolved": "4.0.2",
-        "contentHash": "UmKLY06/yIAAkARvvGHjIS5LA0XEeEn7pbRHmsDcxvbLFla2fqrTTPVBUW7HMttBAwFi2WKvkVzGNu3/0JDdxA=="
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.406, )",
-        "resolved": "1.2.0-beta.406",
-        "contentHash": "YbsYoczQPZyz+4nmQ7bBiU9uQkk7Q2KUizQWEv01S4/ImCdJFiHvJfm8HAINNS0cvSLOA7xM9Y+KWQ2FOYjgkA==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.406"
         }
       },
       "Azure.Core": {
@@ -192,14 +176,6 @@
         "resolved": "2.0.6",
         "contentHash": "ixx72ttlP/Ck+UMWyfiRWVBFKU5XjJySMG33ZWofJp9yy65VF3uOJyGPujr3OedUMo6Uq9umftmHRqhOmUyQ8g=="
       },
-      "Endjin.RecommendedPractices": {
-        "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "2h0r1wg2Oc0LPzsW9VAI+yf4hNOk37oi/zi1SmjlCmT1Jin+4dFxbRXc3uTRvD2mrTGC8VOb0OBnyoZ1Qg41dA==",
-        "dependencies": {
-          "Microsoft.Build.Tasks.Git": "1.1.1"
-        }
-      },
       "Iced": {
         "type": "Transitive",
         "resolved": "1.8.0",
@@ -210,69 +186,23 @@
         "resolved": "1.0.0",
         "contentHash": "K63Y4hORbBcKLWH5wnKgzyn7TOfYzevIEwIedQHBIkmkEBA9SCqgvom+XTuE+fAFGvINGkhFItaZ2dvMGdT5iw=="
       },
-      "Microsoft.Build.Tasks.Git": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
-      },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "2.6.1",
-        "contentHash": "VsT6gg2SPeToP8SK7PEcsH6Ftryb7aOqnXh9xg11zBeov05+63gP3k/TvrR+v85XIa8Nn0y3+qNl4M+qzNLBfw=="
+        "resolved": "3.3.3",
+        "contentHash": "j/rOZtLMVJjrfLRlAMckJLPW/1rze9MT1yfWqSIbUPGRu1m1P0fuo9PmqapwsmePfGB5PJrudQLvmUOAMF0DqQ=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "w57ebW3QIRFPoFFX6GCa6eF2FmuHYaWEJ/sMMHq+PBnHB51dEzLIoAQft1Byqe5nrSo4UUV6v4tad8fkTrKl8w==",
+        "resolved": "4.1.0",
+        "contentHash": "bNzTyxP3iD5FPFHfVDl15Y6/wSoI7e3MeV0lOaj9igbIKTjgrmuw6LoVJ06jUNFA7+KaDC/OIsStWl/FQJz6sQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "2.6.1",
-          "System.AppContext": "4.3.0",
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Collections.Immutable": "1.5.0",
-          "System.Console": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.FileVersionInfo": "4.3.0",
-          "System.Diagnostics.StackTrace": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO.Compression": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Metadata": "1.6.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.CodePages": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.3.0",
-          "System.Threading.Tasks.Parallel": "4.3.0",
-          "System.Threading.Thread": "4.3.0",
-          "System.ValueTuple": "4.3.0",
-          "System.Xml.ReaderWriter": "4.3.0",
-          "System.Xml.XDocument": "4.3.0",
-          "System.Xml.XPath.XDocument": "4.3.0",
-          "System.Xml.XmlDocument": "4.3.0"
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp": {
-        "type": "Transitive",
-        "resolved": "2.10.0",
-        "contentHash": "bTr6j4V7G4ZPhRDUdowdtbEvXsQA4w1TYfOtXiYdv8TF7STl9ShOKtlSVzAusmeEWsZksJm9D1VSxt6XIyNB0w==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[2.10.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.3",
+          "System.Collections.Immutable": "5.0.0",
+          "System.Memory": "4.5.4",
+          "System.Reflection.Metadata": "5.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
+          "System.Text.Encoding.CodePages": "4.5.1",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.Diagnostics.NETCore.Client": {
@@ -438,8 +368,8 @@
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "VdLJOCXhZaEMY7Hm2GKiULmn7IEPFE4XC5LPSfBVCUIA8YLZVh846gtfBJalsPQF2PlzdD7ecX7DZEulJ402ZQ=="
+        "resolved": "2.1.2",
+        "contentHash": "mOJy3M0UN+LUG21dLGMxaWZEP6xYpQEpLuvuEQBaownaX4YuhH6NmNUlN9si+vNkAS6dwJ//N1O4DmLf2CikVg=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
@@ -452,20 +382,6 @@
         "contentHash": "92kNTi1N7zI5wwI2ZXswBRnk61OUYnuYJXrlgOhes5IsAqGmgw9DPGmhUzeY8OaZ8TTrQdDzvgXFnbCHwLzSVA==",
         "dependencies": {
           "Newtonsoft.Json": "10.0.3"
-        }
-      },
-      "Microsoft.SourceLink.Common": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
-      },
-      "Microsoft.SourceLink.GitHub": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
-        "dependencies": {
-          "Microsoft.Build.Tasks.Git": "1.1.1",
-          "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
       "Microsoft.Win32.Registry": {
@@ -490,136 +406,21 @@
           "System.Memory": "4.5.3"
         }
       },
-      "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "HdSSp5MnJSsg08KMfZThpuLPJpPwE5hBXvHwoKWosyHHfe8Mh5WKT0ylEOf6yNzX6Ngjxe4Whkafh5q7Ymac4Q=="
-      },
-      "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "+yH1a49wJMy8Zt4yx5RhJrxO/DBDByAiCzNwiETI+1S4mPdCu0OY4djdciC7Vssk0l22wQaDLrXxXkp+3+7bVA=="
-      },
-      "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "c3YNH1GQJbfIPJeCnr4avseugSqPrxwIqzthYyZDN6EuOyNOzq+y2KSUfRcXauya1sF4foESTgwM5e1A8arAKw=="
-      },
       "runtime.native.System": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "c/qWt2LieNZIj1jGnVNsE2Kl23Ya2aSTBuXMD6V7k9KWr6l16Tqdwq+hJScEpWER9753NWC8h96PaVNY5Ld7Jw==",
+        "resolved": "4.0.0",
+        "contentHash": "QfS/nQI7k/BLgmLrw7qm7YBoULEvgWnPI+cYsbfCVFTW8Aj+i8JhccxcFMu1RWms0YZzF+UHguNBK4Qn89e2Sg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
         }
-      },
-      "runtime.native.System.IO.Compression": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
-        }
-      },
-      "runtime.native.System.Net.Http": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ZVuZJqnnegJhd2k/PtAbbIcZ3aZeITq3sj06oKfMBSfphW3HDmk/t4ObvbOk/JA/swGR0LNqMksAh/f7gpTROg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
-        }
-      },
-      "runtime.native.System.Security.Cryptography.Apple": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
-        "dependencies": {
-          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
-        }
-      },
-      "runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "NS1U+700m4KFRHR5o4vo9DSlTmlCKu/u7dtE5sUHVIPB+xpXxYQvgBgA6wEIeCz6Yfn0Z52/72WYsToCEPJnrw==",
-        "dependencies": {
-          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
-        }
-      },
-      "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "b3pthNgxxFcD+Pc0WSEoC0+md3MyhRS6aCEeenvNE3Fdw1HyJ18ZhRFVJJzIeR/O/jpxPboB805Ho0T3Ul7w8A=="
-      },
-      "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "KeLz4HClKf+nFS7p/6Fi/CqyLXh81FpiGzcmuS8DGi9lUqSnZ6Es23/gv2O+1XVGfrbNmviF7CckBpavkBoIFQ=="
-      },
-      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ=="
-      },
-      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "X7IdhILzr4ROXd8mI1BUCQMSHSQwelUlBjF1JyTKCjXaOGn2fB4EKBxQbCK2VjO3WaWIdlXZL3W6TiIVnrhX4g=="
-      },
-      "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "nyFNiCk/r+VOiIqreLix8yN+q3Wga9+SE8BCgkf+2BwEKiNx6DyvFjCgkfV743/grxv8jHJ8gUK4XEQw7yzRYg=="
-      },
-      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ytoewC6wGorL7KoCAvRfsgoJPJbNq+64k2SqW6JcOAebWsFUvCCYgfzQMrnpvPiEl4OrblUlhF2ji+Q1+SVLrQ=="
-      },
-      "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "I8bKw2I8k58Wx7fMKQJn2R8lamboCAiHfHeV/pS65ScKWMMI0+wJkLYlEKvgW1D/XvSl/221clBoR2q9QNNM7A=="
-      },
-      "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "VB5cn/7OzUfzdnC8tqAIMQciVLiq2epm2NrAm1E9OjNRyG4lVhfR61SMcLizejzQP8R8Uf/0l5qOIbUEi+RdEg=="
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.406",
-        "contentHash": "FclNdBR81ynIo9l1QNlo+l0I/PaFIYaPQPlMram8XVIMh6G6G43KTa1aCxfwTj13uKlAJS/LhLy6KjOPOeAU4w=="
       },
       "System.AppContext": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+        "resolved": "4.1.0",
+        "contentHash": "3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
         "dependencies": {
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ratu44uTIHgeBeI0dE8DWvmXVBSo4u7ozRZZHOMmK/JPpYyo0dAfgSiHlpiObMQ5lEtEyIXA40sKRYg5J6A8uQ==",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Runtime": "4.1.0"
         }
       },
       "System.CodeDom": {
@@ -629,29 +430,12 @@
       },
       "System.Collections": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3Dcj85/TBdVpL5Zr+gEEBUuFe2icOnLalmEh9hfck1PTYbbyWuZgh4fmm2ysCLTrqLQw6t3TgTyJ+VLp+Qb+Lw==",
+        "resolved": "4.0.11",
+        "contentHash": "YUJGz6eFKqS0V//mLt25vFGrrCvOnsXjlvFQs+KimpwNxug9x0Pzy4PlFMU3Q2IzqAa9G2L4LsK3+9vCBK7oTg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Collections.Concurrent": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ztl69Xp0Y/UXCL+3v3tEU+lIy+bvjKNUmopn1wep/a291pVPK7dxBd6T7WnlQqRog+d1a/hSsgRsmFnIBKTPLQ==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Collections.Immutable": {
@@ -662,28 +446,6 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "System.Console": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Text.Encoding": "4.3.0"
-        }
-      },
-      "System.Diagnostics.Debug": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ZUhUOdqmaG5Jk3Xdb8xi5kIyQYAA4PnTNlHx1mu9ZY3qv4ELIdKbnL/akbGaKi2RnNUWaZsAs31rvzFdewTj2g==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -692,93 +454,14 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "System.Diagnostics.FileVersionInfo": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "omCF64wzQ3Q2CeIqkD6lmmxeMZtGHUmzgFMPjfVaOsyqpR66p/JaZzManMw1s33osoAb5gqpncsjie67+yUPHQ==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Reflection.Metadata": "1.4.1",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0"
-        }
-      },
-      "System.Diagnostics.StackTrace": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "BiHg0vgtd35/DM9jvtaC1eKRpWZxr0gcQd643ABG7GnvSlf5pOkY2uyd42mMOJoOmKvnpNj0F4tuoS1pacTwYw==",
-        "dependencies": {
-          "System.IO.FileSystem": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Metadata": "1.4.1",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Diagnostics.Tools": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "UUvkJfSYJMM6x527dJg2VyWPSRqIVB0Z7dbjHst1zmwTXz5CcXSYJFWRpuigfbO1Lf7yfZiIaEUesfnl/g5EyA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Diagnostics.Tracing": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Dynamic.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
-      },
       "System.Globalization": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "kYdVd2f2PAdFGblzFswE4hkNANJBKRmsfa2X5LG2AcWE1c7/4t0pYae1L8vfZ5xvE2nK/R9JprtToA61OSHWIg==",
+        "resolved": "4.0.11",
+        "contentHash": "B95h0YLEL2oSnwF/XjqSWKnwKOy/01VWkNlsCeMTFJLLabflpGV26nK164eRs5GiaRSBGpOxQ3pKoSnnyZN5pg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Globalization.Calendars": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "GUlBtdOWT4LTV3I+9/PJW+56AnnChTaOqqTLFtdmype/L500M2LIyXgmtd9X2P2VOkmJd5c67H5SaC2QcL1bFA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Globalization": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.IO": {
@@ -793,85 +476,27 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.IO.Compression": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Buffers": "4.3.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "runtime.native.System": "4.3.0",
-          "runtime.native.System.IO.Compression": "4.3.0"
-        }
-      },
       "System.IO.FileSystem": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
+        "resolved": "4.0.1",
+        "contentHash": "IBErlVq5jOggAD69bg1t0pJcHaDbJbWNUZTPI96fkYWzwYbN6D9wRHMULLDd9dHsl7C2YsxXL31LMfPI1SWt8w==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
         }
       },
       "System.IO.FileSystem.Primitives": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "6QOb2XFLch7bEc4lIcJH49nJN2HV+OC3fHDgsLVsBVBk3Y4hFAnOBGzJ2lUu7CyDDFo9IBWkSsnbkT6IBwwiMw==",
+        "resolved": "4.0.1",
+        "contentHash": "kWkKD203JJKxJeE74p8aF8y4Qc9r9WQx4C0cHzHPrY3fv/L/IhWnyCHaFJ3H1QPOH6A93whlQ2vG5nHlBDvzWQ==",
         "dependencies": {
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Linq": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5DbqIUpsDp0dFftytzuMmc0oeMdQwjcP/EWxsksIz/w1TcFRkZ3yKKz0PqiYFMmEwPSWw+qNVqD7PJ889JzHbw==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0"
-        }
-      },
-      "System.Linq.Expressions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Management": {
@@ -902,18 +527,6 @@
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
-      },
-      "System.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
       },
       "System.Reflection": {
         "type": "Transitive",
@@ -960,21 +573,10 @@
           "System.Runtime": "4.3.0"
         }
       },
-      "System.Reflection.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "rJkrJD3kBI5B712aRu4DpSIiHRtr6QlfZSQsb0hYHrDCZORXCFjQfoipo2LaMUHoT9i1B7j7MnfaEKWDFmFQNQ==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "1.6.0",
-        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+        "resolved": "5.0.0",
+        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ=="
       },
       "System.Reflection.Primitives": {
         "type": "Transitive",
@@ -988,23 +590,23 @@
       },
       "System.Reflection.TypeExtensions": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "7u6ulLcZbyxB5Gq0nMkQttcdBTx57ibzw+4IOXEfR+sXYQoHvjW5LTLyNr8O22UIMrqYbchJQJnos4eooYzYJA==",
+        "resolved": "4.1.0",
+        "contentHash": "tsQ/ptQ3H5FYfON8lL4MxRk/8kFyE0A+tGPXmVP967cT/gzLHYxIejIYSxp4JmIeFHVP78g/F2FE1mUUTbDtrg==",
         "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Resources.ResourceManager": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "/zrcPkkWdZmI4F92gL/TPumP98AVDu/Wxr3CSJGQQ+XN6wbRZcyfSKVoPo17ilb3iOr0cCRqJInGwNMolqhS8A==",
+        "resolved": "4.0.1",
+        "contentHash": "TxwVeUNoTgUOdQ09gfTjvW411MF+w9MBYL7AtNVc+HtBCFlutPLhUCdZjNkjbhj3bNQWMdHboF0KIWEOjJssbA==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Globalization": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Runtime": {
@@ -1023,35 +625,35 @@
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "guW0uK0fn5fcJJ1tJVXYd7/1h5F+pea1r7FLSOz/f8vPEqbR2ZAknuRDvTQ8PzAilDveOxNjSfr0CHfIQfFk8g==",
+        "resolved": "4.1.0",
+        "contentHash": "CUOHjTT/vgP0qGW22U4/hDlOqXmcPq5YicBaXdUR2UiUoLwBT+olO6we4DVbq57jeX5uXH2uerVZhf0qGj+sVQ==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Runtime.Handles": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "OKiSUN7DmTWeYb3l51A7EYaeNMnvxwE249YtZz7yooT4gOZhmTjIn48KgSsw2k2lYdLgTKNJw/ZIfSElwDRVgg==",
+        "resolved": "4.0.1",
+        "contentHash": "nCJvEKguXEvk2ymk1gqj625vVnlK3/xdGzx0vOKicQkoquaTBJTP13AIYkocSUwHCLNBwUbXTqTWGDxBTWpt7g==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Runtime.InteropServices": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "uv1ynXqiMK8mp1GM3jDqPCFN66eJ5w5XNomaK2XD+TuCroNTLFGeZ+WCmBMcBDyTFKou3P6cR6J/QsaqDp7fGQ==",
+        "resolved": "4.1.0",
+        "contentHash": "16eu3kjHS633yYdkjwShDHZLRNMKVi/s0bY8ODiqJ2RfMhDMAwxZaUaWVnZ2P71kr/or+X9o/xFWtNqz8ivieQ==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Handles": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
         }
       },
       "System.Runtime.InteropServices.RuntimeInformation": {
@@ -1068,17 +670,6 @@
           "runtime.native.System": "4.0.0"
         }
       },
-      "System.Runtime.Numerics": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
-        "dependencies": {
-          "System.Globalization": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0"
-        }
-      },
       "System.Security.AccessControl": {
         "type": "Transitive",
         "resolved": "4.5.0",
@@ -1088,154 +679,10 @@
           "System.Security.Principal.Windows": "4.5.0"
         }
       },
-      "System.Security.Cryptography.Algorithms": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
-          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
-        }
-      },
-      "System.Security.Cryptography.Cng": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "03idZOqFlsKRL4W+LuCpJ6dBYDUWReug6lZjBa3uJWnk5sPCUXckocevTaUA8iT/MFSrY/2HXkOt753xQ/cf8g==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0"
-        }
-      },
-      "System.Security.Cryptography.Csp": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "X4s/FCkEUnRGnwR3aSfVIkldBmtURMhmexALNTwpjklzxWU7yjMk7GHLKOZTNkgnWnE0q7+BCf9N2LVRWxewaA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
-      },
-      "System.Security.Cryptography.Encoding": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "1DEWjZZly9ae9C79vFwqaO5kaOlI5q+3/55ohmq/7dpDyDfc8lYe7YVxJUZ5MF/NtbkRjwFRo14yM4OEo9EmDw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
-        }
-      },
-      "System.Security.Cryptography.OpenSsl": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "h4CEgOgv5PKVF/HwaHzJRiVboL2THYCou97zpmhjghx5frc7fIvlkY1jL+lnIQyChrJDMNEXS6r7byGif8Cy4w==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
-        }
-      },
-      "System.Security.Cryptography.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "7bDIyVFNL/xKeFHjhobUAQqSpJq9YTOpbEs6mR233Et01STBMXNAc/V+BM6dwYGc95gVh/Zf+iVXWzj3mE8DWg==",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
-        }
-      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
-      },
-      "System.Security.Cryptography.X509Certificates": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Globalization.Calendars": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Cng": "4.3.0",
-          "System.Security.Cryptography.Csp": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.OpenSsl": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0",
-          "runtime.native.System": "4.3.0",
-          "runtime.native.System.Net.Http": "4.3.0",
-          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
-        }
       },
       "System.Security.Principal.Windows": {
         "type": "Transitive",
@@ -1257,32 +704,11 @@
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "IRiEFUa5b/Gs5Egg8oqBVoywhtOeaO2KOx3j0RfcYY/raxqBuEK7NXRDgOwtYM8qbi+7S4RPXUbNt+ZxyY0/NQ==",
+        "resolved": "4.5.1",
+        "contentHash": "4J2JQXbftjPMppIHJ7IC+VXQ9XfEagN92vZZNoG12i+zReYlim5dMoXFC1Zzg7tsnKDM7JPo5bYfFK4Jheq44w==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
-      },
-      "System.Text.Encoding.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "YVMK0Bt/A43RmwizJoZ22ei2nmrhobgeiYwFzC4YAN+nue8RF6djXDMog0UCn+brerQoYVyaS+ghy9P/MUVcmw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0",
-          "System.Text.Encoding": "4.3.0"
+          "Microsoft.NETCore.Platforms": "2.1.2",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "System.Text.Encodings.Web": {
@@ -1302,21 +728,13 @@
           "System.Text.Encodings.Web": "6.0.0"
         }
       },
-      "System.Text.RegularExpressions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "RpT2DA+L660cBt1FssIE9CAGpLFdFPuheB7pLpKpn6ZXNby7jDERe8Ua/Ne2xGiwLVG2JOqziiaVCGDon5sKFA==",
-        "dependencies": {
-          "System.Runtime": "4.3.0"
-        }
-      },
       "System.Threading": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "VkUS0kOBcUf3Wwm0TSbrevDDZ6BlM+b/HRiapRFWjM5O0NS0LviG0glKmFK+hhPDd1XFeSdU1GmlLhb2CoVpIw==",
+        "resolved": "4.0.11",
+        "contentHash": "N+3xqIcg3VDKyjwwCGaZ9HawG9aC6cSDI+s7ROma310GQo8vilFZa86hqKppwTHleR/G0sfOzhvgnUxWCR/DrQ==",
         "dependencies": {
-          "System.Runtime": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
         }
       },
       "System.Threading.Tasks": {
@@ -1334,123 +752,10 @@
         "resolved": "4.5.4",
         "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
-      "System.Threading.Tasks.Parallel": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "cbjBNZHf/vQCfcdhzx7knsiygoCKgxL8mZOeocXZn5gWhCdzHIq6bYNKWX0LAJCWYP7bds4yBK8p06YkP0oa0g==",
-        "dependencies": {
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
-        }
-      },
-      "System.Threading.Thread": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "OHmbT+Zz065NKII/ZHcH9XO1dEuLGI1L2k7uYss+9C1jLxTC9kTZZuzUOyXHayRk+dft9CiDf3I/QZ0t8JKyBQ==",
-        "dependencies": {
-          "System.Runtime": "4.3.0"
-        }
-      },
       "System.ValueTuple": {
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
-      },
-      "System.Xml.ReaderWriter": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.3.0"
-        }
-      },
-      "System.Xml.XDocument": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.3.0"
-        }
-      },
-      "System.Xml.XmlDocument": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "lJ8AxvkX7GQxpC6GFCeBj8ThYVyQczx2+f/cWHJU8tjS7YfI6Cv6bon70jVEgs2CiFbmmM8b9j1oZVx0dSI2Ww==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.3.0"
-        }
-      },
-      "System.Xml.XPath": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "v1JQ5SETnQusqmS3RwStF7vwQ3L02imIzl++sewmt23VGygix04pEH+FCj1yWb+z4GDzKiljr1W7Wfvrx0YwgA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.3.0"
-        }
-      },
-      "System.Xml.XPath.XDocument": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "jw9oHHEIVW53mHY9PgrQa98Xo2IZ0ZjrpdOTmtvk+Rvg4tq7dydmxdNqUvJ5YwjDqhn75mBXWttWjiKhWP53LQ==",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.3.0",
-          "System.Xml.XDocument": "4.3.0",
-          "System.Xml.XPath": "4.3.0"
-        }
       },
       "marain.usernotifications.client": {
         "type": "Project",

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/ApiDeliveryChannel/UserNotificationsApiDeliveryChannelClient.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/ApiDeliveryChannel/UserNotificationsApiDeliveryChannelClient.cs
@@ -48,8 +48,8 @@ namespace Marain.UserNotifications.Client.ApiDeliveryChannel
 
             HttpResponseMessage response = await this.SendRequestAndThrowOnFailure(request, cancellationToken).ConfigureAwait(false);
 
-            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            NotificationResource result = await JsonSerializer.DeserializeAsync<NotificationResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
+            using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            NotificationResource result = await JsonSerializer.DeserializeAsync<NotificationResource>(contentStream, this.SerializerOptions, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse<NotificationResource>(
                 response.StatusCode,
@@ -83,8 +83,8 @@ namespace Marain.UserNotifications.Client.ApiDeliveryChannel
 
             HttpResponseMessage response = await this.SendRequestAndThrowOnFailure(request, cancellationToken).ConfigureAwait(false);
 
-            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            PagedNotificationListResource result = await JsonSerializer.DeserializeAsync<PagedNotificationListResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
+            using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            PagedNotificationListResource result = await JsonSerializer.DeserializeAsync<PagedNotificationListResource>(contentStream, this.SerializerOptions, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse<PagedNotificationListResource>(
                 response.StatusCode,
@@ -107,7 +107,7 @@ namespace Marain.UserNotifications.Client.ApiDeliveryChannel
                 throw new ArgumentNullException(nameof(link));
             }
 
-            return this.CallLongRunningOperationEndpointAsync(new Uri(link, UriKind.Relative), HttpMethod.Post);
+            return this.CallLongRunningOperationEndpointAsync(new Uri(link, UriKind.Relative), HttpMethod.Post, cancellationToken);
         }
     }
 }

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/ApiResponse{T}.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/ApiResponse{T}.cs
@@ -17,8 +17,8 @@ namespace Marain.UserNotifications.Client
         /// Initializes a new instance of the <see cref="ApiResponse{T}"/> class.
         /// </summary>
         /// <param name="statusCode">The <see cref="ApiResponse.StatusCode"/>.</param>
-        /// <param name="headers">The <see cref="ApiResponse.Headers"/>.</param>
         /// <param name="body">The <see cref="Body"/>.</param>
+        /// <param name="headers">The <see cref="ApiResponse.Headers"/>.</param>
         public ApiResponse(HttpStatusCode statusCode, in T body, ImmutableDictionary<string, string> headers = null)
         {
             this.StatusCode = statusCode;

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/ClientBase.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/ClientBase.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
+#pragma warning disable CA1822 // Mark members as static - protected members don't use 'this' today but might in the future
+
 namespace Marain.UserNotifications.Client
 {
     using System;
@@ -68,8 +70,8 @@ namespace Marain.UserNotifications.Client
 
             HttpResponseMessage response = await this.SendRequestAndThrowOnFailure(request, cancellationToken).ConfigureAwait(false);
 
-            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            T result = await JsonSerializer.DeserializeAsync<T>(contentStream, this.SerializerOptions).ConfigureAwait(false);
+            using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            T result = await JsonSerializer.DeserializeAsync<T>(contentStream, this.SerializerOptions, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse<T>(
                 response.StatusCode,
@@ -186,7 +188,7 @@ namespace Marain.UserNotifications.Client
             {
                 string responseContent = (response is null || response.Content is null)
                     ? string.Empty
-                    : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
                 throw new UserNotificationsApiException("Unexpected error when calling service; see InnerException for details.", ex)
                 {

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Requests/CreateNotificationForDeliveryChannelsRequest.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Requests/CreateNotificationForDeliveryChannelsRequest.cs
@@ -6,8 +6,6 @@ namespace Marain.UserNotifications.Client.Management.Requests
 {
     using System;
     using System.Collections.Generic;
-    using Corvus.Json;
-    using Marain.UserNotifications.Client.Management.Resources;
 
     /// <summary>
     /// Request to create a new notification with communication type and configured delivery channel.

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationTemplates/EmailTemplateResource.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationTemplates/EmailTemplateResource.cs
@@ -5,10 +5,9 @@
 namespace Marain.UserNotifications.Client.Management.Resources.CommunicationTemplates
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
     using System.Text.Json;
     using System.Text.Json.Serialization;
+
     using Menes.Hal;
 
     /// <summary>

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationTemplates/SmsTemplateResource.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationTemplates/SmsTemplateResource.cs
@@ -5,10 +5,9 @@
 namespace Marain.UserNotifications.Client.Management.Resources.CommunicationTemplates
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
     using System.Text.Json;
     using System.Text.Json.Serialization;
+
     using Menes.Hal;
 
     /// <summary>

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationTemplates/WebPushTemplateResource.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationTemplates/WebPushTemplateResource.cs
@@ -5,10 +5,9 @@
 namespace Marain.UserNotifications.Client.Management.Resources.CommunicationTemplates
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
     using System.Text.Json;
     using System.Text.Json.Serialization;
+
     using Menes.Hal;
 
     /// <summary>

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationType.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/Resources/CommunicationType.cs
@@ -4,9 +4,6 @@
 
 namespace Marain.UserNotifications.Client.Management.Resources
 {
-    using System.Text.Json.Serialization;
-    using Newtonsoft.Json.Converters;
-
     /// <summary>
     /// Values for the communication types a delivery channel could use.
     /// </summary>

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/Management/UserNotificationsManagementClient.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
+#pragma warning disable CA1822 // Mark members as static - protected members don't use 'this' today but might in the future
+
 namespace Marain.UserNotifications.Client.Management
 {
     using System;
@@ -110,7 +112,7 @@ namespace Marain.UserNotifications.Client.Management
                 throw new ArgumentNullException(nameof(notificationType));
             }
 
-            string communicationType = "webPush";
+            const string communicationType = "webPush";
 
             Uri requestUri = this.ConstructUri($"/{tenantId}/marain/usernotifications/templates?notificationType={notificationType}&communicationType={communicationType}");
 
@@ -118,9 +120,9 @@ namespace Marain.UserNotifications.Client.Management
 
             HttpResponseMessage response = await this.SendRequestAndThrowOnFailure(request, cancellationToken).ConfigureAwait(false);
 
-            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
-            WebPushTemplateResource result = await JsonSerializer.DeserializeAsync<WebPushTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
+            WebPushTemplateResource result = await JsonSerializer.DeserializeAsync<WebPushTemplateResource>(contentStream, this.SerializerOptions, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse<WebPushTemplateResource>(
                response.StatusCode,
@@ -152,7 +154,7 @@ namespace Marain.UserNotifications.Client.Management
                 throw new ArgumentNullException(nameof(notificationType));
             }
 
-            string communicationType = "email";
+            const string communicationType = "email";
 
             Uri requestUri = this.ConstructUri($"/{tenantId}/marain/usernotifications/templates?notificationType={notificationType}&communicationType={communicationType}");
 
@@ -160,9 +162,9 @@ namespace Marain.UserNotifications.Client.Management
 
             HttpResponseMessage response = await this.SendRequestAndThrowOnFailure(request, cancellationToken).ConfigureAwait(false);
 
-            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
-            EmailTemplateResource result = await JsonSerializer.DeserializeAsync<EmailTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
+            EmailTemplateResource result = await JsonSerializer.DeserializeAsync<EmailTemplateResource>(contentStream, this.SerializerOptions, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse<EmailTemplateResource>(
                response.StatusCode,
@@ -194,7 +196,7 @@ namespace Marain.UserNotifications.Client.Management
                 throw new ArgumentNullException(nameof(notificationType));
             }
 
-            string communicationType = "sms";
+            const string communicationType = "sms";
 
             Uri requestUri = this.ConstructUri($"/{tenantId}/marain/usernotifications/templates?notificationType={notificationType}&communicationType={communicationType}");
 
@@ -202,9 +204,9 @@ namespace Marain.UserNotifications.Client.Management
 
             HttpResponseMessage response = await this.SendRequestAndThrowOnFailure(request, cancellationToken).ConfigureAwait(false);
 
-            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
-            SmsTemplateResource result = await JsonSerializer.DeserializeAsync<SmsTemplateResource>(contentStream, this.SerializerOptions).ConfigureAwait(false);
+            SmsTemplateResource result = await JsonSerializer.DeserializeAsync<SmsTemplateResource>(contentStream, this.SerializerOptions, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse<SmsTemplateResource>(
                response.StatusCode,
@@ -268,8 +270,8 @@ namespace Marain.UserNotifications.Client.Management
 
             HttpResponseMessage response = await this.SendRequestAndThrowOnFailure(request, cancellationToken).ConfigureAwait(false);
 
-            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            NotificationTemplate result = await JsonSerializer.DeserializeAsync<NotificationTemplate>(contentStream, this.SerializerOptions).ConfigureAwait(false);
+            using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            NotificationTemplate result = await JsonSerializer.DeserializeAsync<NotificationTemplate>(contentStream, this.SerializerOptions, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse<NotificationTemplate>(
                 response.StatusCode,

--- a/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/UserNotificationsApiException.cs
+++ b/Solutions/Marain.UserNotifications.Client/Marain/UserNotifications/Client/UserNotificationsApiException.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1194 // Implement exception constructors.
 namespace Marain.UserNotifications.Client
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Client/Menes/Hal/WebLinkBuilder.cs
+++ b/Solutions/Marain.UserNotifications.Client/Menes/Hal/WebLinkBuilder.cs
@@ -26,7 +26,7 @@ namespace Menes.Hal
         /// <param name="type">The (optional) media type indication of the target resource.</param>
         /// <param name="hreflang">The (optional) language indication of the target resource [RFC5988].</param>
         /// <returns>A <see cref="WebLink"/> initialized with the specified values.</returns>
-        public WebLink CreateWebLink(string href, string? name = null, bool? isTemplated = null, string? title = null, string? profile = null, string? type = null, string? hreflang = null)
+        public static WebLink CreateWebLink(string href, string? name = null, bool? isTemplated = null, string? title = null, string? profile = null, string? type = null, string? hreflang = null)
         {
             if (href is null)
             {
@@ -54,7 +54,7 @@ namespace Menes.Hal
         /// <param name="type">The (optional) media type indication of the target resource.</param>
         /// <param name="hreflang">The (optional) language indication of the target resource [RFC5988].</param>
         /// <returns>A <see cref="WebLink"/> initialized with the specified values.</returns>
-        public WebLink CreateWebLink(ReadOnlySpan<char> href, ReadOnlySpan<char> name = default, bool isTemplated = default, ReadOnlySpan<char> title = default, ReadOnlySpan<char> profile = default, ReadOnlySpan<char> type = default, ReadOnlySpan<char> hreflang = default)
+        public static WebLink CreateWebLink(ReadOnlySpan<char> href, ReadOnlySpan<char> name = default, bool isTemplated = default, ReadOnlySpan<char> title = default, ReadOnlySpan<char> profile = default, ReadOnlySpan<char> type = default, ReadOnlySpan<char> hreflang = default)
         {
             using var stream = new MemoryStream();
             var writer = new Utf8JsonWriter(stream);
@@ -77,7 +77,7 @@ namespace Menes.Hal
         /// <param name="utf8Type">The (optional) media type indication of the target resource.</param>
         /// <param name="utf8Hreflang">The (optional) language indication of the target resource [RFC5988].</param>
         /// <returns>A <see cref="WebLink"/> initialized with the specified values.</returns>
-        public WebLink CreateWebLink(ReadOnlySpan<byte> utf8Href, ReadOnlySpan<byte> utf8Name = default, bool isTemplated = default, ReadOnlySpan<byte> utf8Title = default, ReadOnlySpan<byte> utf8Profile = default, ReadOnlySpan<byte> utf8Type = default, ReadOnlySpan<byte> utf8Hreflang = default)
+        public static WebLink CreateWebLink(ReadOnlySpan<byte> utf8Href, ReadOnlySpan<byte> utf8Name = default, bool isTemplated = default, ReadOnlySpan<byte> utf8Title = default, ReadOnlySpan<byte> utf8Profile = default, ReadOnlySpan<byte> utf8Type = default, ReadOnlySpan<byte> utf8Hreflang = default)
         {
             using var stream = new MemoryStream();
             var writer = new Utf8JsonWriter(stream);
@@ -100,7 +100,7 @@ namespace Menes.Hal
         /// <param name="type">The (optional) media type indication of the target resource.</param>
         /// <param name="hreflang">The (optional) language indication of the target resource [RFC5988].</param>
         /// <returns>A <see cref="WebLink"/> initialized with the specified values.</returns>
-        public WebLink CreateWebLink(in JsonElement href, in JsonElement name = default, in JsonElement isTemplated = default, in JsonElement title = default, in JsonElement profile = default, in JsonElement type = default, in JsonElement hreflang = default)
+        public static WebLink CreateWebLink(in JsonElement href, in JsonElement name = default, in JsonElement isTemplated = default, in JsonElement title = default, in JsonElement profile = default, in JsonElement type = default, in JsonElement hreflang = default)
         {
             using var stream = new MemoryStream();
             var writer = new Utf8JsonWriter(stream);

--- a/Solutions/Marain.UserNotifications.Deployment/packages.config
+++ b/Solutions/Marain.UserNotifications.Deployment/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Build.Tasks.Git" version="1.0.0" developmentDependency="true" />
-  <package id="Microsoft.SourceLink.Common" version="1.0.0" developmentDependency="true" />
-  <package id="Microsoft.SourceLink.GitHub" version="1.0.0" developmentDependency="true" />
-</packages>

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/CompleteLongRunningOperationActivity.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/CompleteLongRunningOperationActivity.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'
 namespace Marain.UserNotifications.Management.Host.Activities
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/CreateNotificationActivity.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/CreateNotificationActivity.cs
@@ -6,9 +6,11 @@ namespace Marain.UserNotifications.Management.Host.Activities
 {
     using System;
     using System.Threading.Tasks;
+
     using Corvus.Tenancy;
-    using Marain.NotificationTemplates;
+
     using Marain.UserNotifications.Management.Host.Helpers;
+
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Extensions.Logging;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/FailLongRunningOperationActivity.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/FailLongRunningOperationActivity.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'
 namespace Marain.UserNotifications.Management.Host.Activities
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/StartLongRunningOperationActivity.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Activities/StartLongRunningOperationActivity.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'
 namespace Marain.UserNotifications.Management.Host.Activities
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Composer/GenerateTemplateComposer.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Composer/GenerateTemplateComposer.cs
@@ -6,15 +6,18 @@ namespace Marain.UserNotifications.Management.Host.Composer
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
     using System.Threading.Tasks;
+
     using Corvus.Json;
+
     using DotLiquid;
+
     using Marain.Models;
     using Marain.NotificationTemplates;
     using Marain.NotificationTemplates.CommunicationTemplates;
+
     using Microsoft.Extensions.Logging;
+
     using NotificationTemplate = Marain.NotificationTemplates.NotificationTemplate;
 
     /// <inheritdoc/>
@@ -52,8 +55,8 @@ namespace Marain.UserNotifications.Management.Host.Composer
                         try
                         {
                             (EmailTemplate, string?) emailRawTemplate = await templateStore.GetAsync<EmailTemplate>(notificationType, CommunicationType.Email).ConfigureAwait(false);
-                            string? emailBody = await this.GenerateTemplateForFieldAsync(emailRawTemplate.Item1.Body, propertiesHash).ConfigureAwait(false);
-                            string? emailSubject = await this.GenerateTemplateForFieldAsync(emailRawTemplate.Item1.Subject, propertiesHash).ConfigureAwait(false);
+                            string? emailBody = await GenerateTemplateForFieldAsync(emailRawTemplate.Item1.Body, propertiesHash).ConfigureAwait(false);
+                            string? emailSubject = await GenerateTemplateForFieldAsync(emailRawTemplate.Item1.Subject, propertiesHash).ConfigureAwait(false);
 
                             if (string.IsNullOrEmpty(emailSubject))
                             {
@@ -83,7 +86,7 @@ namespace Marain.UserNotifications.Management.Host.Composer
                         try
                         {
                             (SmsTemplate, string?) smsRawTemplate = await templateStore.GetAsync<SmsTemplate>(notificationType, CommunicationType.Sms).ConfigureAwait(false);
-                            string? smsBody = await this.GenerateTemplateForFieldAsync(smsRawTemplate.Item1.Body!, propertiesHash).ConfigureAwait(false);
+                            string? smsBody = await GenerateTemplateForFieldAsync(smsRawTemplate.Item1.Body, propertiesHash).ConfigureAwait(false);
 
                             if (string.IsNullOrEmpty(smsBody))
                             {
@@ -104,10 +107,10 @@ namespace Marain.UserNotifications.Management.Host.Composer
                         try
                         {
                             (WebPushTemplate, string?) webPushRawTemplate = await templateStore.GetAsync<WebPushTemplate>(notificationType, CommunicationType.WebPush).ConfigureAwait(false);
-                            string? webPushTitle = await this.GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.Title, propertiesHash).ConfigureAwait(false);
-                            string? webPushBody = await this.GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.Body, propertiesHash).ConfigureAwait(false);
-                            string? webPushImage = await this.GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.Image, propertiesHash).ConfigureAwait(false);
-                            string? actionUrl = await this.GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.ActionUrl, propertiesHash).ConfigureAwait(false);
+                            string? webPushTitle = await GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.Title, propertiesHash).ConfigureAwait(false);
+                            string? webPushBody = await GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.Body, propertiesHash).ConfigureAwait(false);
+                            string? webPushImage = await GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.Image, propertiesHash).ConfigureAwait(false);
+                            string? actionUrl = await GenerateTemplateForFieldAsync(webPushRawTemplate.Item1.ActionUrl, propertiesHash).ConfigureAwait(false);
 
                             if (string.IsNullOrEmpty(webPushTitle))
                             {
@@ -150,7 +153,7 @@ namespace Marain.UserNotifications.Management.Host.Composer
         /// <param name="templateBody">A string with handlebars. </param>
         /// <param name="properties">A dictionary of all properties that can be used to render the templateBody string. </param>
         /// <returns>A rendered string. </returns>
-        private async Task<string?> GenerateTemplateForFieldAsync(string? templateBody, Hash properties)
+        private static async Task<string?> GenerateTemplateForFieldAsync(string? templateBody, Hash properties)
         {
             if (string.IsNullOrEmpty(templateBody))
             {

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Mappers/EmailTemplateMapper.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Mappers/EmailTemplateMapper.cs
@@ -64,7 +64,7 @@ namespace Marain.UserNotifications.Management.Host.Mappers
                 "self",
                 ("tenantId", context.CurrentTenantId),
                 ("notificationType", resource.NotificationType),
-                ("communicationType", CommunicationType.Email.ToString()));
+                ("communicationType", nameof(CommunicationType.Email)));
 
             return new ValueTask<HalDocument>(response);
         }

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Mappers/SmsTemplateMapper.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Mappers/SmsTemplateMapper.cs
@@ -63,7 +63,7 @@ namespace Marain.UserNotifications.Management.Host.Mappers
                 "self",
                 ("tenantId", context.CurrentTenantId),
                 ("notificationType", resource.NotificationType),
-                ("communicationType", CommunicationType.Sms.ToString()));
+                ("communicationType", nameof(CommunicationType.Sms)));
 
             return new ValueTask<HalDocument>(response);
         }

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Mappers/WebPushTemplateMapper.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Mappers/WebPushTemplateMapper.cs
@@ -66,7 +66,7 @@ namespace Marain.UserNotifications.Management.Host.Mappers
                 "self",
                 ("tenantId", context.CurrentTenantId),
                 ("notificationType", resource.NotificationType),
-                ("communicationType", CommunicationType.WebPush.ToString()));
+                ("communicationType", nameof(CommunicationType.WebPush)));
 
             return new ValueTask<HalDocument>(response);
         }

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Models/CreateNotificationForDeliveryChannelsRequest.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Models/CreateNotificationForDeliveryChannelsRequest.cs
@@ -22,9 +22,9 @@ namespace Marain.UserNotifications.Management.Host.Models
         /// <param name="notificationType">The <see cref="NotificationType" />.</param>
         /// <param name="userIds">The <see cref="UserIds" />.</param>
         /// <param name="timestamp">The <see cref="Timestamp" />.</param>
-        /// <param name="deliveryChannelConfiguredPerCommunicationType">The <see cref="DeliveryChannelConfiguredPerCommunicationType"/>.</param>
         /// <param name="properties">The <see cref="Properties" />.</param>
         /// <param name="correlationIds">The <see cref="CorrelationIds" />.</param>
+        /// <param name="deliveryChannelConfiguredPerCommunicationType">The <see cref="DeliveryChannelConfiguredPerCommunicationType"/>.</param>
         public CreateNotificationForDeliveryChannelsRequest(
             string notificationType,
             string[] userIds,

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/CreateNotificationsService.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/CreateNotificationsService.cs
@@ -5,18 +5,20 @@
 namespace Marain.UserNotifications.Management.Host.OpenApi
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
+
     using Corvus.Tenancy;
-    using Marain.Models;
+
     using Marain.Operations.Client.OperationsControl;
     using Marain.Operations.Client.OperationsControl.Models;
     using Marain.Services.Tenancy;
     using Marain.UserNotifications.Management.Host.Helpers;
     using Marain.UserNotifications.Management.Host.Models;
     using Marain.UserNotifications.Management.Host.Orchestrations;
+
     using Menes;
     using Menes.Exceptions;
+
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
     /// <summary>

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/CreateOrUpdateTemplateService.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/CreateOrUpdateTemplateService.cs
@@ -6,14 +6,16 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
 {
     using System;
     using System.Threading.Tasks;
+
     using Corvus.Tenancy;
+
     using Marain.Models;
     using Marain.NotificationTemplates;
     using Marain.NotificationTemplates.CommunicationTemplates;
     using Marain.Services.Tenancy;
+
     using Menes;
     using Menes.Exceptions;
-    using Microsoft.Azure.Storage;
 
     /// <summary>
     /// Implements the create or update template endpoint for the management API.

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/DurableFunctionsOpenApiContext.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/DurableFunctionsOpenApiContext.cs
@@ -50,22 +50,18 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
         }
 
         /// <inheritdoc/>
-        public object AdditionalContext
+        public object? AdditionalContext
         {
             get
             {
                 return this.additionalProperties;
             }
 
-#pragma warning disable CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
-#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
             set
             {
                 this.additionalProperties = value as DurableFunctionsOpenApiContextAdditionalProperties
                     ?? throw new ArgumentException("AdditionalContext can only be set to a non-null value of type 'DurableFunctionsOpenApiContextAdditionalProperties'");
             }
-#pragma warning restore CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
-#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
         }
     }
 }

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GenerateTemplateService.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GenerateTemplateService.cs
@@ -7,14 +7,16 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+
     using Corvus.Tenancy;
+
     using Marain.Models;
     using Marain.NotificationTemplates;
     using Marain.Services.Tenancy;
     using Marain.UserNotifications.Management.Host.Composer;
     using Marain.UserNotifications.Management.Host.Models;
+
     using Menes;
-    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Implements the generate template endpoint for the management API.
@@ -28,7 +30,6 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
 
         private readonly IMarainServicesTenancy marainServicesTenancy;
         private readonly ITenantedNotificationTemplateStoreFactory tenantedTemplateStoreFactory;
-        private readonly ILogger<GenerateTemplateService> logger;
         private readonly IGenerateTemplateComposer generateTemplateComposer;
 
         /// <summary>
@@ -37,16 +38,13 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
         /// <param name="marainServicesTenancy">Marain tenancy services.</param>
         /// <param name="tenantedTemplateStoreFactory">Template store factory.</param>
         /// <param name="generateTemplateComposer">The composer to generate the templated notification per communication channel.</param>
-        /// <param name="logger">The logger for GenerateTemplateService.</param>
         public GenerateTemplateService(
             IMarainServicesTenancy marainServicesTenancy,
             ITenantedNotificationTemplateStoreFactory tenantedTemplateStoreFactory,
-            IGenerateTemplateComposer generateTemplateComposer,
-            ILogger<GenerateTemplateService> logger)
+            IGenerateTemplateComposer generateTemplateComposer)
         {
             this.marainServicesTenancy = marainServicesTenancy;
             this.tenantedTemplateStoreFactory = tenantedTemplateStoreFactory;
-            this.logger = logger;
             this.generateTemplateComposer = generateTemplateComposer;
         }
 

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GetNotificationStatusService.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GetNotificationStatusService.cs
@@ -26,11 +26,15 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
         /// <param name="continuationToken">A continuation token from a previous request.</param>
         /// <returns>The notifications, as an OpenApiResult.</returns>
         [OperationId(GetNotificationStatusOperationId)]
+#pragma warning disable RCS1163 // Unused parameter - not implemented yet.
+#pragma warning disable IDE0060 // Unused parameter - not implemented yet.
+#pragma warning disable IDE0079 // Remove unnecessary suppression - IDE0060 keeps changing its mind about whether it applies here
         public Task<OpenApiResult> GetNotificationsAsync(
             IOpenApiContext context,
             string notificationId,
             int? maxItems,
             string? continuationToken)
+#pragma warning restore IDE0079, IDE0060, RCS1163
         {
             return Task.FromResult(this.NotImplementedResult());
         }

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GetNotificationsService.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/OpenApi/GetNotificationsService.cs
@@ -27,12 +27,16 @@ namespace Marain.UserNotifications.Management.Host.OpenApi
         /// <param name="continuationToken">A continuation token from a previous request.</param>
         /// <returns>The notifications, as an OpenApiResult.</returns>
         [OperationId(GetNotificationsOperationId)]
+#pragma warning disable RCS1163 // Unused parameter - not implemented yet.
+#pragma warning disable IDE0060 // Unused parameter - not implemented yet.
+#pragma warning disable IDE0079 // Remove unnecessary suppression - IDE0060 keeps changing its mind about whether it applies here
         public Task<OpenApiResult> GetNotificationsAsync(
             IOpenApiContext context,
             string? userId,
             string? notificationType,
             int? maxItems,
             string? continuationToken)
+#pragma warning restore IDE0079, IDE0060, RCS1163
         {
             return Task.FromResult(this.NotImplementedResult());
         }

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/CreateAndDispatchNotificationOrchestration.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/CreateAndDispatchNotificationOrchestration.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'
 namespace Marain.UserNotifications.Management.Host.Orchestrations
 {
     using System.Threading.Tasks;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/CreateAndDispatchNotificationsOrchestration.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/CreateAndDispatchNotificationsOrchestration.cs
@@ -2,16 +2,16 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'
 namespace Marain.UserNotifications.Management.Host.Orchestrations
 {
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+
     using Marain.UserNotifications.Management.Host.Activities;
     using Marain.UserNotifications.Management.Host.Helpers;
     using Marain.UserNotifications.Management.Host.Models;
-    using Marain.UserNotifications.Management.Host.OpenApi;
+
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Extensions.Logging;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/UpdateNotificationDeliveryStatusesOrchestration.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/UpdateNotificationDeliveryStatusesOrchestration.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'
 namespace Marain.UserNotifications.Management.Host.Orchestrations
 {
     using System.Collections.Generic;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/UpdateNotificationReadStatusesOrchestration.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Orchestrations/UpdateNotificationReadStatusesOrchestration.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'
 namespace Marain.UserNotifications.Management.Host.Orchestrations
 {
     using System.Collections.Generic;

--- a/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Startup.cs
+++ b/Solutions/Marain.UserNotifications.Management.Host/Marain/UserNotifications/Management/Host/Startup.cs
@@ -6,7 +6,6 @@
 
 namespace Marain.UserNotifications.Management.Host
 {
-    using System.Net.Http;
     using Marain.Extensions.DependencyInjection;
     using Marain.NotificationTemplates;
     using Marain.NotificationTemplates.CommunicationTemplates;
@@ -15,7 +14,9 @@ namespace Marain.UserNotifications.Management.Host
     using Marain.UserNotifications.Management.Host.Mappers;
     using Marain.UserNotifications.Management.Host.OpenApi;
     using Marain.UserNotifications.ThirdParty.DeliveryChannels.Airship;
+
     using Menes;
+
     using Microsoft.Azure.Functions.Extensions.DependencyInjection;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Extensions.Configuration;

--- a/Solutions/Marain.UserNotifications.OpenApi/Marain/UserNotifications/OpenApi/ApiDeliveryChannel/GetNotificationsForUserService.cs
+++ b/Solutions/Marain.UserNotifications.OpenApi/Marain/UserNotifications/OpenApi/ApiDeliveryChannel/GetNotificationsForUserService.cs
@@ -121,7 +121,9 @@ namespace Marain.UserNotifications.OpenApi.ApiDeliveryChannel
 
                 if (notificationsToMarkAsDelivered.Any())
                 {
-                    this.logger.LogDebug($"Updating notification state to 'Delivered' for {notificationsToMarkAsDelivered.Count()} notifications.");
+                    this.logger.LogDebug(
+                        "Updating notification state to 'Delivered' for {NotificationsMarkedAsDeliveredCount} notifications.",
+                        notificationsToMarkAsDelivered.Count());
 
                     DateTimeOffset timestamp = DateTimeOffset.UtcNow;
                     IEnumerable<BatchDeliveryStatusUpdateRequestItem> deliveryStatusUpdateBatch = notificationsToMarkAsDelivered.Select(
@@ -144,7 +146,8 @@ namespace Marain.UserNotifications.OpenApi.ApiDeliveryChannel
                         CancellationToken.None).ConfigureAwait(false);
 
                     this.logger.LogInformation(
-                        $"Sent request to update notification delivery status; long running operation Url is {response.Headers["Location"]}");
+                        "Sent request to update notification delivery status; long running operation Url is {UpdateStatusUrl}",
+                        response.Headers["Location"]);
                 }
             }
             catch (Exception ex)
@@ -165,7 +168,7 @@ namespace Marain.UserNotifications.OpenApi.ApiDeliveryChannel
 
             try
             {
-                this.logger.LogDebug($"Retrieving notifications for user {userId}");
+                this.logger.LogDebug("Retrieving notifications for user {UserId}", userId);
                 results = string.IsNullOrEmpty(continuationToken)
                                     ? await userNotificationStore.GetAsync(userId, sinceNotificationId, maxItems).ConfigureAwait(false)
                                     : await userNotificationStore.GetAsync(userId, continuationToken).ConfigureAwait(false);

--- a/Solutions/Marain.UserNotifications.OpenApi/Marain/UserNotifications/OpenApi/ApiDeliveryChannel/MarkNotificationAsReadService.cs
+++ b/Solutions/Marain.UserNotifications.OpenApi/Marain/UserNotifications/OpenApi/ApiDeliveryChannel/MarkNotificationAsReadService.cs
@@ -28,8 +28,8 @@ namespace Marain.UserNotifications.OpenApi.ApiDeliveryChannel
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkNotificationAsReadService"/> class.
         /// </summary>
-        /// <param name="marainServicesTenancy">Marain tenancy services.</param>
         /// <param name="managementApiClient">The client for the management API.</param>
+        /// <param name="marainServicesTenancy">Marain tenancy services.</param>
         public MarkNotificationAsReadService(
             IUserNotificationsManagementClient managementApiClient,
             IMarainServicesTenancy marainServicesTenancy)

--- a/Solutions/Marain.UserNotifications.Specs/Bindings/FunctionsApiBindings.cs
+++ b/Solutions/Marain.UserNotifications.Specs/Bindings/FunctionsApiBindings.cs
@@ -20,9 +20,9 @@ namespace Marain.UserNotifications.Specs.Bindings
 
         public const int ApiDeliveryChannelPort = 7001;
 
-        public static readonly Uri ManagementApiBaseUri = new Uri($"http://localhost:{ManagementApiPort}");
+        public static readonly Uri ManagementApiBaseUri = new($"http://localhost:{ManagementApiPort}");
 
-        public static readonly Uri ApiDeliveryChannelBaseUri = new Uri($"http://localhost:{ApiDeliveryChannelPort}");
+        public static readonly Uri ApiDeliveryChannelBaseUri = new($"http://localhost:{ApiDeliveryChannelPort}");
 
         [BeforeFeature("useApis", Order = BindingSequence.FunctionStartup)]
         public static Task StartManagementApi(FeatureContext featureContext)

--- a/Solutions/Marain.UserNotifications.Specs/Bindings/TransientTenantBindings.cs
+++ b/Solutions/Marain.UserNotifications.Specs/Bindings/TransientTenantBindings.cs
@@ -83,10 +83,7 @@ namespace Marain.UserNotifications.Specs.Bindings
                 await testTable.DeleteAsync().ConfigureAwait(false);
             }).ConfigureAwait(false);
 
-            await featureContext.RunAndStoreExceptionsAsync(() =>
-            {
-                return tenantManager.CleanupAsync();
-            }).ConfigureAwait(false);
+            await featureContext.RunAndStoreExceptionsAsync(async () => await tenantManager.CleanupAsync()).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Solutions/Marain.UserNotifications.Specs/Steps/ApiSteps.cs
+++ b/Solutions/Marain.UserNotifications.Specs/Steps/ApiSteps.cs
@@ -149,7 +149,7 @@ namespace Marain.UserNotifications.Specs.Steps
             HttpResponseMessage response = this.scenarioContext.Get<HttpResponseMessage>();
             Uri operationLocation = response.Headers.Location!;
 
-            return this.LongRunningOperationPropertyCheck(
+            return LongRunningOperationPropertyCheck(
                 operationLocation,
                 operationPropertyPath,
                 timeout,
@@ -168,7 +168,7 @@ namespace Marain.UserNotifications.Specs.Steps
             HttpResponseMessage response = this.scenarioContext.Get<HttpResponseMessage>();
             Uri operationLocation = response.Headers.Location!;
 
-            return this.LongRunningOperationPropertyCheck(
+            return LongRunningOperationPropertyCheck(
                 operationLocation,
                 operationPropertyPath,
                 timeout,
@@ -187,7 +187,7 @@ namespace Marain.UserNotifications.Specs.Steps
             HttpResponseMessage response = this.scenarioContext.Get<HttpResponseMessage>();
             Uri operationLocation = response.Headers.Location!;
 
-            return this.LongRunningOperationPropertyCheck(
+            return LongRunningOperationPropertyCheck(
                 operationLocation,
                 operationPropertyPath,
                 timeout,
@@ -361,7 +361,7 @@ namespace Marain.UserNotifications.Specs.Steps
             Assert.IsFalse(string.IsNullOrWhiteSpace(eTag));
         }
 
-        private Task LongRunningOperationPropertyCheck(Uri location, string operationPropertyPath, int timeoutSeconds, Action<string> testValue)
+        private static Task LongRunningOperationPropertyCheck(Uri location, string operationPropertyPath, int timeoutSeconds, Action<string> testValue)
         {
             var tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
@@ -423,27 +423,11 @@ namespace Marain.UserNotifications.Specs.Steps
             }
         }
 
-        private async Task SendPutRequest(StringContent requestContent, string path)
-        {
-            HttpResponseMessage response = await HttpClient.PutAsync(
-                new Uri(FunctionsApiBindings.ManagementApiBaseUri, path),
-                requestContent).ConfigureAwait(false);
-
-            this.scenarioContext.Set(response);
-
-            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-            if (!string.IsNullOrEmpty(responseContent))
-            {
-                this.scenarioContext.Set(responseContent, ResponseContent);
-            }
-        }
-
         private async Task SendPostRequest(Uri baseUri, string path, object? data)
         {
             HttpContent? content = null;
 
-            if (!(data is null))
+            if (data is not null)
             {
                 IJsonSerializerSettingsProvider serializerSettingsProvider = this.serviceProvider.GetRequiredService<IJsonSerializerSettingsProvider>();
                 string requestJson = JsonConvert.SerializeObject(data, serializerSettingsProvider.Instance);

--- a/Solutions/Marain.UserNotifications.Specs/Steps/NotificationSteps.cs
+++ b/Solutions/Marain.UserNotifications.Specs/Steps/NotificationSteps.cs
@@ -54,7 +54,7 @@ namespace Marain.UserNotifications.Specs.Steps
                 Assert.AreEqual(expected.Metadata.CorrelationIds[idx], actual.Metadata.CorrelationIds[idx], $"Correlation Ids at index {idx} do not match.");
             }
 
-            Assert.AreEqual(expected.ChannelStatuses.Count(), actual.ChannelStatuses.Count());
+            Assert.AreEqual(expected.ChannelStatuses.Length, actual.ChannelStatuses.Length);
             foreach (UserNotificationStatus expectedStatus in expected.ChannelStatuses)
             {
                 UserNotificationStatus? actualStatus = actual.ChannelStatuses.FirstOrDefault(s => s.DeliveryChannelId == expectedStatus.DeliveryChannelId);

--- a/Solutions/Marain.UserNotifications.Storage.AzureStorage/Marain/UserNotifications/Storage/AzureStorage/AzureTableUserNotificationStore.cs
+++ b/Solutions/Marain.UserNotifications.Storage.AzureStorage/Marain/UserNotifications/Storage/AzureStorage/AzureTableUserNotificationStore.cs
@@ -9,12 +9,15 @@ namespace Marain.UserNotifications.Storage.AzureStorage
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
+
     using Azure;
-    using Azure.Core;
     using Azure.Data.Tables;
+
     using Corvus.Extensions.Json;
+
     using Marain.UserNotifications;
     using Marain.UserNotifications.Storage.AzureStorage.Internal;
+
     using Microsoft.Extensions.Logging;
 
     /// <summary>

--- a/Solutions/Marain.UserNotifications.Storage.AzureStorage/Marain/UserNotifications/Storage/AzureStorage/AzureTableUserNotificationStoreException.cs
+++ b/Solutions/Marain.UserNotifications.Storage.AzureStorage/Marain/UserNotifications/Storage/AzureStorage/AzureTableUserNotificationStoreException.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-#pragma warning disable RCS1194 // Roslynator's 'all the constructors' fixation
-
 namespace Marain.UserNotifications.Storage.AzureStorage
 {
     using System;

--- a/Solutions/Marain.UserNotifications.Storage.AzureStorage/Marain/UserNotifications/Storage/AzureStorage/Template/AzureBlobTemplateStore.cs
+++ b/Solutions/Marain.UserNotifications.Storage.AzureStorage/Marain/UserNotifications/Storage/AzureStorage/Template/AzureBlobTemplateStore.cs
@@ -48,7 +48,7 @@ namespace Marain.UserNotifications.Storage.AzureStorage
         public async Task<(T Template, string? ETag)> GetAsync<T>(string notificationType, CommunicationType communicationType)
         {
             // Gets the blob reference by the notificationType
-            BlobClient blob = this.blobContainer.GetBlobClient(this.GetBlockBlobName(notificationType, communicationType));
+            BlobClient blob = this.blobContainer.GetBlobClient(GetBlockBlobName(notificationType, communicationType));
 
             try
             {
@@ -62,7 +62,7 @@ namespace Marain.UserNotifications.Storage.AzureStorage
             catch (RequestFailedException ex)
             when (ex.Status == 404)
             {
-                throw new NotificationTemplateNotFoundException(this.GetBlockBlobName(notificationType, communicationType));
+                throw new NotificationTemplateNotFoundException(GetBlockBlobName(notificationType, communicationType));
             }
         }
 
@@ -72,7 +72,7 @@ namespace Marain.UserNotifications.Storage.AzureStorage
             this.logger.LogDebug("CreateOrUpdate: Storing template for notification type ", notificationType);
 
             // Gets the blob reference by the NotificationType
-            BlobClient blockBlob = this.blobContainer.GetBlobClient(this.GetBlockBlobName(notificationType, communicationType));
+            BlobClient blockBlob = this.blobContainer.GetBlobClient(GetBlockBlobName(notificationType, communicationType));
 
             // Serialise the TemplateWrapper object
             string templateBlob = JsonConvert.SerializeObject(template, this.serializerSettingsProvider.Instance);
@@ -101,7 +101,7 @@ namespace Marain.UserNotifications.Storage.AzureStorage
             return template;
         }
 
-        private string GetBlockBlobName(string notificationType, CommunicationType communicationType)
+        private static string GetBlockBlobName(string notificationType, CommunicationType communicationType)
         {
             return $"{notificationType}:{communicationType}";
         }

--- a/Solutions/Marain.UserNotifications.Storage.AzureStorage/Microsoft/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Solutions/Marain.UserNotifications.Storage.AzureStorage/Microsoft/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,9 +4,8 @@
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    using System;
     using System.Linq;
-    using Corvus.Storage.Azure.TableStorage.Tenancy;
+
     using Marain.NotificationTemplates;
     using Marain.UserNotifications;
     using Marain.UserNotifications.Storage.AzureStorage;

--- a/Solutions/Marain.UserNotifications.ThirdParty.DeliveryChannels/Marain/UserNotifications/ThirdParty/DeliveryChannels/Airship/AirshipClient.cs
+++ b/Solutions/Marain.UserNotifications.ThirdParty.DeliveryChannels/Marain/UserNotifications/ThirdParty/DeliveryChannels/Airship/AirshipClient.cs
@@ -21,11 +21,11 @@ namespace Marain.UserNotifications.ThirdParty.DeliveryChannels.Airship
     /// </summary>
     public class AirshipClient : IAirshipClient
     {
-        private string baseUrl = "https://go.urbanairship.com";
-        private AsyncRetryPolicy<HttpResponseMessage> retryPolicy;
+        private const string BaseUrl = "https://go.urbanairship.com";
+        private readonly AsyncRetryPolicy<HttpResponseMessage> retryPolicy;
 
         // Exceptions to be handled by the retry policy
-        private HttpStatusCode[] httpStatusCodesWorthRetrying =
+        private readonly HttpStatusCode[] httpStatusCodesWorthRetrying =
          {
             HttpStatusCode.RequestTimeout, // 408
             HttpStatusCode.InternalServerError, // 500
@@ -89,7 +89,7 @@ namespace Marain.UserNotifications.ThirdParty.DeliveryChannels.Airship
 
             var request = new HttpRequestMessage()
             {
-                RequestUri = new Uri($"{this.baseUrl}/api/push"),
+                RequestUri = new Uri($"{BaseUrl}/api/push"),
                 Method = HttpMethod.Post,
                 Content = new StringContent(requestContent),
             };

--- a/Solutions/Marain.UserNotifications.ThirdParty.DeliveryChannels/Marain/UserNotifications/ThirdParty/DeliveryChannels/Airship/AirshipClientFactory.cs
+++ b/Solutions/Marain.UserNotifications.ThirdParty.DeliveryChannels/Marain/UserNotifications/ThirdParty/DeliveryChannels/Airship/AirshipClientFactory.cs
@@ -23,6 +23,6 @@ namespace Marain.UserNotifications.ThirdParty.DeliveryChannels.Airship
         }
 
         /// <inheritdoc/>
-        public AirshipClient GetAirshipClient(string applicationKey, string masterSecret) => new AirshipClient(this.httpClient, applicationKey, masterSecret);
+        public AirshipClient GetAirshipClient(string applicationKey, string masterSecret) => new(this.httpClient, applicationKey, masterSecret);
     }
 }

--- a/Solutions/Marain.UserNotifications.ThirdParty.DeliveryChannels/Marain/UserNotifications/ThirdParty/DeliveryChannels/Airship/Models/AirshipWebPushResponse.cs
+++ b/Solutions/Marain.UserNotifications.ThirdParty.DeliveryChannels/Marain/UserNotifications/ThirdParty/DeliveryChannels/Airship/Models/AirshipWebPushResponse.cs
@@ -4,9 +4,8 @@
 
 namespace Marain.UserNotifications.ThirdParty.DeliveryChannels.Airship.Models
 {
-    using System;
     using System.Collections.Generic;
-    using System.Text;
+
     using Newtonsoft.Json;
 
     /// <summary>


### PR DESCRIPTION
Upgrading to `Endjin.RecommendedPractices` v2.1 increased the number of analyzer messages. This gets that back down to 0.