### PR TITLE
Deployment updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,7 @@ coverage.cobertura.xml
 
 # VS Code config files
 /.vscode
+
+# Local build outputs
+_packages/
+*.sbom.*

--- a/Solutions/Marain.UserNotifications.Deployment/Templates/functions-app-settings-api-delivery-channel-host.json
+++ b/Solutions/Marain.UserNotifications.Deployment/Templates/functions-app-settings-api-delivery-channel-host.json
@@ -55,7 +55,7 @@
         "AzureWebJobsDashboard": "[parameters('storageAccountConnectionString')]",
         "AzureWebJobsStorage": "[parameters('storageAccountConnectionString')]",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('applicationInsightsInstrumentationKey')]",
-        "FUNCTIONS_EXTENSION_VERSION": "~3",
+        "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet",
 
         "UserNotificationsManagementClient:BaseUri": "[parameters('managementClientBaseUrl')]",

--- a/Solutions/Marain.UserNotifications.Deployment/Templates/functions-app-settings-management-host.json
+++ b/Solutions/Marain.UserNotifications.Deployment/Templates/functions-app-settings-management-host.json
@@ -57,7 +57,7 @@
         "AzureWebJobsDashboard": "[parameters('storageAccountConnectionString')]",
         "AzureWebJobsStorage": "[parameters('storageAccountConnectionString')]",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('applicationInsightsInstrumentationKey')]",
-        "FUNCTIONS_EXTENSION_VERSION": "~3",
+        "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet",
 
         "TenancyClient:TenancyServiceBaseUri": "[parameters('tenancyServiceBaseUri')]",

--- a/Solutions/Marain.UserNotifications.Specs/Marain.UserNotifications.Specs.csproj
+++ b/Solutions/Marain.UserNotifications.Specs/Marain.UserNotifications.Specs.csproj
@@ -27,14 +27,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Corvus.Configuration.TestEnvironment" Version="1.2.5" />
-    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow.NUnit" Version="2.0.0" />
+    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow.NUnit" Version="1.4.11" />
 	 
     <PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 	
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="3.1.0" />
+    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.3.3" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,10 +46,6 @@
     <ProjectReference Include="..\Marain.UserNotifications.Management.Host\Marain.UserNotifications.Management.Host.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Solutions/Marain.UserNotifications.Specs/Marain.UserNotifications.Specs.csproj
+++ b/Solutions/Marain.UserNotifications.Specs/Marain.UserNotifications.Specs.csproj
@@ -27,14 +27,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Corvus.Configuration.TestEnvironment" Version="1.2.5" />
-    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow.NUnit" Version="1.4.11" />
+    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow.NUnit" Version="2.0.0" />
 	 
     <PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 	
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.3.3" />
+    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,6 +46,10 @@
     <ProjectReference Include="..\Marain.UserNotifications.Management.Host\Marain.UserNotifications.Management.Host.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ jobs:
     service_connection_nuget_org: $(Endjin_Service_Connection_NuGet_Org)
     service_connection_github: $(Endjin_Service_Connection_GitHub)
     solution_to_build: $(Endjin_Solution_To_Build)
+    compileTasksServiceConnection: endjin-acr-reader
     postCustomEnvironmentVariables:
       - powershell: |
           Write-Host "##vso[task.setvariable variable=AzureServicesAuthConnectionString]$Env:ENDJIN_AZURESERVICESAUTHCONNECTIONSTRING"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,16 @@ trigger:
     include:
     - '*'
 
+parameters:
+- name: Endjin.ForceDeploy
+  type: boolean
+  default: false
+  displayName: When checked, a new release will be created and NuGet packages published; otherwise only 'master' branch changes will be published
+- name: Endjin.InternalPublish
+  type: boolean
+  default: false
+  displayName: When checked, NuGet packages will be published to an internal feed; this is independent of whether a public release is performed 
+
 resources:
   repositories:
     - repository: recommended_practices

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,14 +7,18 @@ trigger:
     - '*'
 
 parameters:
-- name: Endjin.ForceDeploy
+- name: ForcePublish
   type: boolean
   default: false
   displayName: When checked, a new release will be created and NuGet packages published; otherwise only 'master' branch changes will be published
-- name: Endjin.InternalPublish
+- name: InternalPublish
   type: boolean
   default: false
-  displayName: When checked, NuGet packages will be published to an internal feed; this is independent of whether a public release is performed 
+  displayName: When checked, NuGet packages will be published to an internal feed; this is independent of whether a public release is performed
+- name: ForceRelease
+  type: boolean
+  default: false
+  displayName: When checked, a GitHub Release will be created but NuGet packages will not be published (unless other options are enabled)
 
 resources:
   repositories:
@@ -22,6 +26,11 @@ resources:
       type: github
       name: endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub
       endpoint: marain-dotnet-github
+
+variables:
+  Endjin.ForcePublish: ${{ parameters.ForcePublish }}
+  Endjin.InternalPublish: ${{ parameters.InternalPublish }}
+  Endjin.ForceRelease: ${{ parameters.ForceRelease }}
 
 jobs:
 - template: templates/build.and.release.scripted.yml@recommended_practices

--- a/build.ps1
+++ b/build.ps1
@@ -138,7 +138,8 @@ $SkipPublish = $false
 #
 $SolutionToBuild = (Resolve-Path (Join-Path $here ".\Solutions\Marain.UserNotifications.sln")).Path
 $ProjectsToPublish = @(
-    # "Solutions/MySolution/MyWebSite/MyWebSite.csproj"
+    "Solutions\Marain.UserNotifications.Hosting.AspNetCore\Marain.UserNotifications.Hosting.AspNetCore.csproj"
+    "Solutions\Marain.UserNotifications.Management.Host\Marain.UserNotifications.Management.Host.csproj"
 )
 $NuSpecFilesToPackage = @(
     # "Solutions/MySolution/MyProject/MyProject.nuspec"
@@ -164,9 +165,7 @@ task PreVersion {}
 task PostVersion {}
 task PreBuild {}
 task PostBuild {}
-task PreTest {
-    gci env:/ | ft -autosize | out-string | write-host
-}
+task PreTest {}
 task PostTest {}
 task PreTestReport {}
 task PostTestReport {}

--- a/build.ps1
+++ b/build.ps1
@@ -71,10 +71,10 @@ param (
     [string] $BuildModulePath,
 
     [Parameter()]
-    [version] $BuildModuleVersion = "0.2.15",
+    [version] $BuildModuleVersion = "1.1.1",
 
     [Parameter()]
-    [version] $InvokeBuildModuleVersion = "5.7.1"
+    [version] $InvokeBuildModuleVersion = "5.10.1"
 )
 
 $ErrorActionPreference = $ErrorActionPreference ? $ErrorActionPreference : 'Stop'

--- a/build.ps1
+++ b/build.ps1
@@ -164,7 +164,9 @@ task PreVersion {}
 task PostVersion {}
 task PreBuild {}
 task PostBuild {}
-task PreTest {}
+task PreTest {
+    gci env:/ | ft -autosize | out-string | write-host
+}
 task PostTest {}
 task PreTestReport {}
 task PostTestReport {}


### PR DESCRIPTION
Resolves deployment issues since the .NET 6 upgrade.

Due to updates to `Marain.Operations` this change also required the latest `Marain.TenantManagement`.